### PR TITLE
Extract reusable UI components

### DIFF
--- a/src/components/AgeRestriction.tsx
+++ b/src/components/AgeRestriction.tsx
@@ -1,0 +1,28 @@
+import { Users } from 'lucide-react';
+import React from 'react';
+
+interface AgeRestrictionProps {
+  minAge: number | null | undefined;
+}
+
+const getAgeRestrictionText = (minAge: number | null | undefined): string => {
+  if (minAge === null || minAge === undefined) return 'Age requirement unknown';
+  switch (minAge) {
+    case 0:
+      return 'All Ages';
+    case 18:
+      return '18+';
+    case 21:
+      return '21+';
+    default:
+      return `${minAge}+`;
+  }
+};
+
+export const AgeRestriction: React.FC<AgeRestrictionProps> = ({ minAge }) => (
+  <div className="flex items-center text-sm text-gray-500">
+    <Users className="mr-2 h-4 w-4" />
+    {getAgeRestrictionText(minAge)}
+  </div>
+);
+

--- a/src/components/EntityBadges.tsx
+++ b/src/components/EntityBadges.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+
+interface EntityBadgesProps {
+  entities: Array<{ id: number; name: string }> | undefined;
+  onClick?: (name: string) => void;
+}
+
+export const EntityBadges: React.FC<EntityBadgesProps> = ({ entities, onClick }) => {
+  if (!entities || entities.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {entities.map(entity => (
+        <Badge
+          key={entity.id}
+          variant="default"
+          className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1"
+          onClick={onClick ? () => onClick(entity.name) : undefined}
+        >
+          {entity.name}
+        </Badge>
+      ))}
+    </div>
+  );
+};

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -3,26 +3,15 @@ import { api } from '../lib/api';
 import { Event } from '../types/api';
 import { formatDate } from '../lib/utils';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Loader2, Music, CalendarDays, MapPin, Users, DollarSign, Ticket } from 'lucide-react';
+import { Loader2, Music, CalendarDays, MapPin, DollarSign, Ticket } from 'lucide-react';
+import { AgeRestriction } from './AgeRestriction';
+import { EntityBadges } from './EntityBadges';
+import { TagBadges } from './TagBadges';
 import { ImageLightbox } from './ImageLightbox';
 import { useContext } from 'react';
 import { EventFilterContext } from '../context/EventFilterContext';
 import { useState, useEffect } from 'react';
 
-const getAgeRestriction = (minAge: number | null | undefined): string => {
-  if (minAge === null || minAge === undefined) return 'Age requirement unknown';
-  switch (minAge) {
-    case 0:
-      return 'All Ages';
-    case 18:
-      return '18+';
-    case 21:
-      return '21+';
-    default:
-      return `${minAge}+`;  // Just in case there's a different age restriction
-  }
-};
 
 interface EventCardProps {
   event: Event;
@@ -53,7 +42,6 @@ const EventCard = ({ event, allImages, imageIndex }: EventCardProps) => {
     });
   };
 
-  const ageRestriction = getAgeRestriction(event.min_age);
   const placeHolderImage = `${window.location.origin}/event-placeholder.png`;
   const embedsEnabled = false; // This should be set based on your feature flag or config
 
@@ -147,10 +135,7 @@ const EventCard = ({ event, allImages, imageIndex }: EventCardProps) => {
               )}
 
               {event.min_age !== null && event.min_age !== undefined && (
-                <div className="flex items-center text-sm text-gray-500">
-                  <Users className="mr-2 h-4 w-4" />
-                  {ageRestriction}
-                </div>
+                <AgeRestriction minAge={event.min_age} />
               )}
 
               {(event.presale_price || event.door_price) && (
@@ -181,35 +166,12 @@ const EventCard = ({ event, allImages, imageIndex }: EventCardProps) => {
               )}
             </div>
 
-            {event.entities && event.entities.length > 0 && (
-              <div className="flex flex-wrap gap-2 mt-2">
-                {event.entities.map((entity) => (
-                  <Badge
-                    key={entity.id}
-                    variant="default"
-                    className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1"
-                    onClick={() => handleEntityClick(entity.name)}
-                  >
-                    {entity.name}
-                  </Badge>
-                ))}
-              </div>
-            )}
+            <EntityBadges
+              entities={event.entities}
+              onClick={handleEntityClick}
+            />
 
-            {event.tags && event.tags.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {event.tags.map((tag) => (
-                  <Badge
-                    key={tag.id}
-                    variant="secondary"
-                    className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
-                    onClick={() => handleTagClick(tag.name)}
-                  >
-                    {tag.name}
-                  </Badge>
-                ))}
-              </div>
-            )}
+            <TagBadges tags={event.tags} onClick={handleTagClick} />
           </div>
         </CardContent>
       </div>

--- a/src/components/EventCardCondensed.tsx
+++ b/src/components/EventCardCondensed.tsx
@@ -2,25 +2,14 @@ import { useNavigate } from '@tanstack/react-router';
 import { Event } from '../types/api';
 import { formatDate } from '../lib/utils';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { CalendarDays, MapPin, Users, DollarSign, Ticket } from 'lucide-react';
+import { CalendarDays, MapPin, DollarSign, Ticket } from 'lucide-react';
+import { AgeRestriction } from './AgeRestriction';
+import { EntityBadges } from './EntityBadges';
+import { TagBadges } from './TagBadges';
 import { ImageLightbox } from './ImageLightbox';
 import { useContext } from 'react';
 import { EventFilterContext } from '../context/EventFilterContext';
 
-const getAgeRestriction = (minAge: number | null | undefined): string => {
-    if (minAge === null || minAge === undefined) return 'Age requirement unknown';
-    switch (minAge) {
-        case 0:
-            return 'All Ages';
-        case 18:
-            return '18+';
-        case 21:
-            return '21+';
-        default:
-            return `${minAge}+`;  // Just in case there's a different age restriction
-    }
-};
 
 interface EventCardProps {
     event: Event;
@@ -44,7 +33,6 @@ const EventCardCondensed = ({ event, allImages, imageIndex }: EventCardProps) =>
         });
     };
 
-    const ageRestriction = getAgeRestriction(event.min_age);
 
     return (
         <Card className="group overflow-hidden transition-all hover:shadow-md">
@@ -117,10 +105,7 @@ const EventCardCondensed = ({ event, allImages, imageIndex }: EventCardProps) =>
                                 )}
 
                                 {event.min_age !== null && event.min_age !== undefined && (
-                                    <div className="flex items-center text-sm text-gray-500">
-                                        <Users className="mr-2 h-4 w-4" />
-                                        {ageRestriction}
-                                    </div>
+                                    <AgeRestriction minAge={event.min_age} />
                                 )}
 
                                 {(event.presale_price || event.door_price) && (
@@ -151,34 +136,9 @@ const EventCardCondensed = ({ event, allImages, imageIndex }: EventCardProps) =>
                                 )}
                             </div>
 
-                            {event.entities && event.entities.length > 0 && (
-                                <div className="flex flex-wrap gap-2 mt-2">
-                                    {event.entities.map((entity) => (
-                                        <Badge
-                                            key={entity.id}
-                                            variant="default"
-                                            className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1"
-                                        >
-                                            {entity.name}
-                                        </Badge>
-                                    ))}
-                                </div>
-                            )}
+                            <EntityBadges entities={event.entities} />
 
-                            {event.tags && event.tags.length > 0 && (
-                                <div className="flex flex-wrap gap-2">
-                                    {event.tags.map((tag) => (
-                                        <Badge
-                                            key={tag.id}
-                                            variant="secondary"
-                                            className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
-                                            onClick={() => handleTagClick(tag.name)}
-                                        >
-                                            {tag.name}
-                                        </Badge>
-                                    ))}
-                                </div>
-                            )}
+                            <TagBadges tags={event.tags} onClick={handleTagClick} />
                         </div>
                     </CardContent>
                 </div>

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -4,7 +4,8 @@ import { api } from '../lib/api';
 import { Event } from '../types/api';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Loader2, ArrowLeft, CalendarDays, MapPin, Users, DollarSign, Ticket, Music, X, ChevronLeft, ChevronRight, Image as ImageIcon } from 'lucide-react';
+import { Loader2, ArrowLeft, CalendarDays, MapPin, DollarSign, Ticket, Music, X, ChevronLeft, ChevronRight, Image as ImageIcon } from 'lucide-react';
+import { AgeRestriction } from './AgeRestriction';
 import { formatDate } from '../lib/utils';
 import { useState, useEffect } from 'react';
 import { PhotoResponse } from '../types/api';
@@ -139,15 +140,7 @@ export default function EventDetail({ slug }: { slug: string }) {
                                         )}
 
                                         {event.min_age !== null && event.min_age !== undefined && (
-                                            <div className="flex items-center gap-2 text-gray-600">
-                                                <Users className="h-5 w-5" />
-                                                <span>
-                                                    {event.min_age === 0 ? 'All Ages' :
-                                                        event.min_age === 18 ? '18+' :
-                                                            event.min_age === 21 ? '21+' :
-                                                                `${event.min_age}+`}
-                                                </span>
-                                            </div>
+                                            <AgeRestriction minAge={event.min_age} />
                                         )}
                                     </div>
 

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -3,6 +3,7 @@ import { useEvents } from '../hooks/useEvents';
 import EventCard from './EventCard';
 import EventFilter from './EventFilters';
 import { Pagination } from './Pagination';
+import SortControls from './SortControls';
 import { Loader2 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -206,6 +207,13 @@ export default function Events() {
                                         </Button>
                                     )}
                                 </div>
+                                <SortControls
+                                    sort={sort}
+                                    setSort={setSort}
+                                    direction={direction}
+                                    setDirection={setDirection}
+                                    sortOptions={sortOptions}
+                                />
                             </div>
 
                             {filtersVisible && (

--- a/src/components/SeriesCard.tsx
+++ b/src/components/SeriesCard.tsx
@@ -2,25 +2,14 @@ import { useNavigate } from '@tanstack/react-router';
 import { Series } from '../types/api';
 import { formatDate } from '../lib/utils';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { CalendarDays, MapPin, Users } from 'lucide-react';
+import { CalendarDays, MapPin } from 'lucide-react';
+import { AgeRestriction } from './AgeRestriction';
+import { EntityBadges } from './EntityBadges';
+import { TagBadges } from './TagBadges';
 import { ImageLightbox } from './ImageLightbox';
 import { useContext } from 'react';
 import { SeriesFilterContext } from '../context/SeriesFilterContext';
 
-const getAgeRestriction = (minAge: number | null | undefined): string => {
-  if (minAge === null || minAge === undefined) return 'Age requirement unknown';
-  switch (minAge) {
-    case 0:
-      return 'All Ages';
-    case 18:
-      return '18+';
-    case 21:
-      return '21+';
-    default:
-      return `${minAge}+`;  // Just in case there's a different age restriction
-  }
-};
 
 interface SeriesCardProps {
   series: Series;
@@ -48,7 +37,6 @@ const SeriesCard = ({ series, allImages, imageIndex }: SeriesCardProps) => {
     });
   };
 
-  const ageRestriction = getAgeRestriction(series.min_age);
   const placeHolderImage = `${window.location.origin}/event-placeholder.png`;
 
   return (
@@ -123,44 +111,15 @@ const SeriesCard = ({ series, allImages, imageIndex }: SeriesCardProps) => {
               )}
 
               {series.min_age !== null && series.min_age !== undefined && (
-                <div className="flex items-center text-sm text-gray-500">
-                  <Users className="mr-2 h-4 w-4" />
-                  {ageRestriction}
-                </div>
+                <AgeRestriction minAge={series.min_age} />
               )}
 
 
             </div>
 
-            {series.entities && series.entities.length > 0 && (
-              <div className="flex flex-wrap gap-2 mt-2">
-                {series.entities.map((entity) => (
-                  <Badge
-                    key={entity.id}
-                    variant="default"
-                    className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1"
-                    onClick={() => handleEntityClick(entity.name)}
-                  >
-                    {entity.name}
-                  </Badge>
-                ))}
-              </div>
-            )}
+            <EntityBadges entities={series.entities} onClick={handleEntityClick} />
 
-            {series.tags && series.tags.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {series.tags.map((tag) => (
-                  <Badge
-                    key={tag.id}
-                    variant="secondary"
-                    className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
-                    onClick={() => handleTagClick(tag.name)}
-                  >
-                    {tag.name}
-                  </Badge>
-                ))}
-              </div>
-            )}
+            <TagBadges tags={series.tags} onClick={handleTagClick} />
           </div>
         </CardContent>
       </div>

--- a/src/components/SeriesDetail.tsx
+++ b/src/components/SeriesDetail.tsx
@@ -4,7 +4,8 @@ import { api } from '../lib/api';
 import { Series } from '../types/api';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Loader2, ArrowLeft, CalendarDays, MapPin, Users, DollarSign, Ticket } from 'lucide-react';
+import { Loader2, ArrowLeft, CalendarDays, MapPin, DollarSign, Ticket } from 'lucide-react';
+import { AgeRestriction } from './AgeRestriction';
 import { formatDate } from '../lib/utils';
 
 export default function SeriesDetail({ slug }: { slug: string }) {
@@ -109,15 +110,7 @@ export default function SeriesDetail({ slug }: { slug: string }) {
                                         )}
 
                                         {series.min_age !== null && series.min_age !== undefined && (
-                                            <div className="flex items-center gap-2 text-gray-600">
-                                                <Users className="h-5 w-5" />
-                                                <span>
-                                                    {series.min_age === 0 ? 'All Ages' :
-                                                        series.min_age === 18 ? '18+' :
-                                                            series.min_age === 21 ? '21+' :
-                                                                `${series.min_age}+`}
-                                                </span>
-                                            </div>
+                                            <AgeRestriction minAge={series.min_age} />
                                         )}
                                     </div>
 

--- a/src/components/TagBadges.tsx
+++ b/src/components/TagBadges.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+
+interface TagBadgesProps {
+  tags: Array<{ id: number; name: string }> | undefined;
+  onClick?: (name: string) => void;
+}
+
+export const TagBadges: React.FC<TagBadgesProps> = ({ tags, onClick }) => {
+  if (!tags || tags.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tags.map(tag => (
+        <Badge
+          key={tag.id}
+          variant="secondary"
+          className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
+          onClick={onClick ? () => onClick(tag.name) : undefined}
+        >
+          {tag.name}
+        </Badge>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- extract `AgeRestriction`, `EntityBadges`, and `TagBadges` components for reuse
- update event and series cards/details to use new components
- expose `SortControls` in `Events` to satisfy tests

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6849a32b8e5c832297fd7183ce5d1a9d