### PR TITLE
Add tag listing and detail pages

### DIFF
--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -3,7 +3,7 @@ import { Link } from '@tanstack/react-router';
 import { authService } from '../services/auth.service';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { Button } from './ui/button';
-import { HiCalendar, HiOfficeBuilding, HiUser, HiMoon, HiSun, HiMenu, HiCollection } from 'react-icons/hi';
+import { HiCalendar, HiOfficeBuilding, HiUser, HiMoon, HiSun, HiMenu, HiCollection, HiTag } from 'react-icons/hi';
 import { Sheet, SheetContent, SheetTrigger } from './ui/sheet';
 
 const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
@@ -34,6 +34,10 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
         <Link to="/series" className="flex items-center gap-2 hover:underline">
           <HiCollection />
           <span className=" xl:inline">Series Listings</span>
+        </Link>
+        <Link to="/tags" className="flex items-center gap-2 hover:underline">
+          <HiTag />
+          <span className=" xl:inline">Tags</span>
         </Link>
         {authService.isAuthenticated() && (
           <Link to="/account" className="flex items-center gap-2 hover:underline">

--- a/src/components/TagBadges.tsx
+++ b/src/components/TagBadges.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
+import { Link } from '@tanstack/react-router';
 
 interface TagBadgesProps {
-  tags: Array<{ id: number; name: string }> | undefined;
+  tags: Array<{ id: number; name: string; slug?: string }> | undefined;
   onClick?: (name: string) => void;
 }
 
@@ -11,14 +12,25 @@ export const TagBadges: React.FC<TagBadgesProps> = ({ tags, onClick }) => {
   return (
     <div className="flex flex-wrap gap-2">
       {tags.map(tag => (
-        <Badge
-          key={tag.id}
-          variant="secondary"
-          className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
-          onClick={onClick ? () => onClick(tag.name) : undefined}
-        >
-          {tag.name}
-        </Badge>
+        onClick ? (
+          <Badge
+            key={tag.id}
+            variant="secondary"
+            className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
+            onClick={() => onClick(tag.name)}
+          >
+            {tag.name}
+          </Badge>
+        ) : (
+          <Link key={tag.id} to="/tags/$slug" params={{ slug: tag.slug ?? tag.name }}>
+            <Badge
+              variant="secondary"
+              className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
+            >
+              {tag.name}
+            </Badge>
+          </Link>
+        )
       ))}
     </div>
   );

--- a/src/components/TagDetail.tsx
+++ b/src/components/TagDetail.tsx
@@ -1,0 +1,157 @@
+import { Link } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { Tag, Event, Entity, Series, PaginatedResponse } from '../types/api';
+import { Button } from '@/components/ui/button';
+import { Loader2, ArrowLeft } from 'lucide-react';
+import EventCardCondensed from './EventCardCondensed';
+import EntityCard from './EntityCard';
+import SeriesCard from './SeriesCard';
+
+export default function TagDetail({ slug }: { slug: string }) {
+    const { data: tag, isLoading, error } = useQuery<Tag>({
+        queryKey: ['tag', slug],
+        queryFn: async () => {
+            const { data } = await api.get<Tag>(`/tags/${slug}`);
+            return data;
+        },
+    });
+
+    const { data: eventsData, isLoading: eventsLoading } = useQuery<PaginatedResponse<Event>>({
+        queryKey: ['tagEvents', slug],
+        queryFn: async () => {
+            const params = new URLSearchParams();
+            params.append('page', '1');
+            params.append('limit', '5');
+            params.append('filters[tag]', slug);
+            params.append('sort', 'start_at');
+            params.append('direction', 'desc');
+            const { data } = await api.get<PaginatedResponse<Event>>(`/events?${params.toString()}`);
+            return data;
+        },
+        enabled: !!tag,
+    });
+
+    const { data: entitiesData, isLoading: entitiesLoading } = useQuery<PaginatedResponse<Entity>>({
+        queryKey: ['tagEntities', slug],
+        queryFn: async () => {
+            const params = new URLSearchParams();
+            params.append('page', '1');
+            params.append('limit', '5');
+            params.append('filters[tag]', slug);
+            const { data } = await api.get<PaginatedResponse<Entity>>(`/entities?${params.toString()}`);
+            return data;
+        },
+        enabled: !!tag,
+    });
+
+    const { data: seriesData, isLoading: seriesLoading } = useQuery<PaginatedResponse<Series>>({
+        queryKey: ['tagSeries', slug],
+        queryFn: async () => {
+            const params = new URLSearchParams();
+            params.append('page', '1');
+            params.append('limit', '5');
+            params.append('filters[tag]', slug);
+            const { data } = await api.get<PaginatedResponse<Series>>(`/series?${params.toString()}`);
+            return data;
+        },
+        enabled: !!tag,
+    });
+
+    if (isLoading) {
+        return (
+            <div className="flex h-96 items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+            </div>
+        );
+    }
+
+    if (error || !tag) {
+        return (
+            <div className="text-center text-red-500">Error loading tag. Please try again later.</div>
+        );
+    }
+
+    const eventImages = eventsData?.data.filter(e => e.primary_photo && e.primary_photo_thumbnail).map(e => ({
+        src: e.primary_photo!,
+        alt: e.name,
+        thumbnail: e.primary_photo_thumbnail,
+    })) ?? [];
+
+    const entityImages = entitiesData?.data.filter(e => e.primary_photo && e.primary_photo_thumbnail).map(e => ({
+        src: e.primary_photo!,
+        alt: e.name,
+        thumbnail: e.primary_photo_thumbnail,
+    })) ?? [];
+
+    const seriesImages = seriesData?.data.filter(s => s.primary_photo && s.primary_photo_thumbnail).map(s => ({
+        src: s.primary_photo!,
+        alt: s.name,
+        thumbnail: s.primary_photo_thumbnail,
+    })) ?? [];
+
+    return (
+        <div className="min-h-screen">
+            <div className="mx-auto px-6 py-8 max-w-[2400px]">
+                <div className="space-y-6">
+                    <div className="flex items-center gap-4">
+                        <Button variant="outline" size="sm" className="flex items-center gap-2" asChild>
+                            <Link to="/tags">
+                                <ArrowLeft className="h-4 w-4" />
+                                Back to Tags
+                            </Link>
+                        </Button>
+                    </div>
+                    <h1 className="text-4xl font-bold text-gray-900">{tag.name}</h1>
+
+                    <div className="space-y-8">
+                        <div>
+                            <h2 className="text-2xl font-semibold mb-4">Events</h2>
+                            {eventsLoading ? (
+                                <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+                            ) : eventsData && eventsData.data.length > 0 ? (
+                                <div className="space-y-4">
+                                    {eventsData.data.map((event, idx) => (
+                                        <EventCardCondensed key={event.id} event={event} allImages={eventImages} imageIndex={idx} />
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-gray-500">No events found.</p>
+                            )}
+                        </div>
+
+                        <div>
+                            <h2 className="text-2xl font-semibold mb-4">Entities</h2>
+                            {entitiesLoading ? (
+                                <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+                            ) : entitiesData && entitiesData.data.length > 0 ? (
+                                <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
+                                    {entitiesData.data.map((entity, idx) => (
+                                        <EntityCard key={entity.id} entity={entity} allImages={entityImages} imageIndex={idx} />
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-gray-500">No entities found.</p>
+                            )}
+                        </div>
+
+                        <div>
+                            <h2 className="text-2xl font-semibold mb-4">Series</h2>
+                            {seriesLoading ? (
+                                <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+                            ) : seriesData && seriesData.data.length > 0 ? (
+                                <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
+                                    {seriesData.data.map((series, idx) => (
+                                        <SeriesCard key={series.id} series={series} allImages={seriesImages} imageIndex={idx} />
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-gray-500">No series found.</p>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/TagFilters.tsx
+++ b/src/components/TagFilters.tsx
@@ -1,0 +1,30 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface TagFiltersProps {
+    filters: {
+        name: string;
+    };
+    onFilterChange: (filters: TagFiltersProps['filters']) => void;
+}
+
+export default function TagFilters({ filters, onFilterChange }: TagFiltersProps) {
+    return (
+        <div className="space-y-4">
+            <div className="grid gap-6 md:grid-cols-4 lg:grid-cols-4">
+                <div className="space-y-2">
+                    <Label htmlFor="name">Tag Name</Label>
+                    <div className="relative">
+                        <Input
+                            id="name"
+                            placeholder="Search tags..."
+                            className="pl-3"
+                            value={filters.name}
+                            onChange={(e) => onFilterChange({ ...filters, name: e.target.value })}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -1,0 +1,190 @@
+import { useState, useEffect } from 'react';
+import { useTags } from '../hooks/useTags';
+import TagFilters from './TagFilters';
+import { Pagination } from './Pagination';
+import SortControls from './SortControls';
+import { Loader2 } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import { TagFilterContext } from '../context/TagFilterContext';
+import { TagFilters as TagFiltersType } from '../types/filters';
+import { Badge } from '@/components/ui/badge';
+import { Link } from '@tanstack/react-router';
+import { Button } from '@/components/ui/button';
+import { X } from 'lucide-react';
+
+const sortOptions = [
+    { value: 'name', label: 'Name' },
+    { value: 'created_at', label: 'Recently Added' },
+];
+
+export default function Tags() {
+    const [filtersVisible, setFiltersVisible] = useState<boolean>(() => {
+        const savedState = localStorage.getItem('filtersVisible');
+        return savedState ? JSON.parse(savedState) : true;
+    });
+
+    useEffect(() => {
+        localStorage.setItem('filtersVisible', JSON.stringify(filtersVisible));
+    }, [filtersVisible]);
+
+    const toggleFilters = () => {
+        setFiltersVisible(!filtersVisible);
+    };
+
+    const [filters, setFilters] = useState<TagFiltersType>({
+        name: '',
+    });
+
+    const [page, setPage] = useState(1);
+    const [itemsPerPage, setItemsPerPage] = useLocalStorage('tagsPerPage', 25);
+    const [sort, setSort] = useState('name');
+    const [direction, setDirection] = useState<'asc' | 'desc'>('asc');
+
+    const { data, isLoading, error } = useTags({
+        filters,
+        page,
+        itemsPerPage,
+        sort,
+        direction,
+    });
+
+    const handlePageChange = (newPage: number) => {
+        setPage(newPage);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    const handleItemsPerPageChange = (count: number) => {
+        setItemsPerPage(count);
+        setPage(1);
+    };
+
+    const renderPagination = () => {
+        if (!data) return null;
+        return (
+            <Pagination
+                currentPage={page}
+                totalPages={data.last_page}
+                onPageChange={handlePageChange}
+                itemCount={data.data.length}
+                totalItems={data.total}
+                itemsPerPage={itemsPerPage}
+                onItemsPerPageChange={handleItemsPerPageChange}
+                sort={sort}
+                setSort={setSort}
+                direction={direction}
+                setDirection={setDirection}
+                sortOptions={sortOptions}
+            />
+        );
+    };
+
+    const hasActiveFilters = filters.name.trim() !== '';
+
+    const handleClearAllFilters = () => {
+        setFilters({ name: '' });
+    };
+
+    return (
+        <TagFilterContext.Provider value={{ filters, setFilters }}>
+            <div className="bg-background text-foreground min-h-screen p-4">
+                <div className="mx-auto px-6 py-8 max-w-[2400px]">
+                    <div className="space-y-8">
+                        <div className="flex flex-col space-y-2">
+                            <h1 className="text-4xl font-bold tracking-tight text-gray-900">Tags</h1>
+                            <p className="text-lg text-gray-500">Browse all tags</p>
+                        </div>
+
+                        <div className="relative">
+                            <div className="flex items-center gap-4">
+                                <div className="flex items-center gap-2">
+                                    <button
+                                        onClick={toggleFilters}
+                                        className="mb-4 flex items-center border rounded-t-md px-4 py-2 shadow-sm"
+                                    >
+                                        {filtersVisible ? (
+                                            <>
+                                                <FontAwesomeIcon icon={faChevronUp} className="mr-2" />
+                                                Hide Filters
+                                            </>
+                                        ) : (
+                                            <>
+                                                <FontAwesomeIcon icon={faChevronDown} className="mr-2" />
+                                                Show Filters
+                                            </>
+                                        )}
+                                    </button>
+                                    {hasActiveFilters && (
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={handleClearAllFilters}
+                                            className="mb-4 text-gray-500 hover:text-gray-900"
+                                        >
+                                            Clear All
+                                            <X className="ml-2 h-4 w-4" />
+                                        </Button>
+                                    )}
+                                </div>
+                                <SortControls
+                                    sort={sort}
+                                    setSort={setSort}
+                                    direction={direction}
+                                    setDirection={setDirection}
+                                    sortOptions={sortOptions}
+                                />
+                            </div>
+                            {filtersVisible && (
+                                <Card className="border-gray-100 shadow-sm">
+                                    <CardContent className="p-6 space-y-4">
+                                        <TagFilters filters={filters} onFilterChange={setFilters} />
+                                    </CardContent>
+                                </Card>
+                            )}
+                        </div>
+
+                        {error ? (
+                            <Alert variant="destructive">
+                                <AlertDescription>
+                                    There was an error loading tags. Please try again later.
+                                </AlertDescription>
+                            </Alert>
+                        ) : isLoading ? (
+                            <div className="flex h-96 items-center justify-center">
+                                <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+                            </div>
+                        ) : data?.data && data.data.length > 0 ? (
+                            <>
+                                {renderPagination()}
+
+                                <div className="flex flex-wrap gap-2">
+                                    {data.data.map((tag) => (
+                                        <Link key={tag.id} to="/tags/$slug" params={{ slug: tag.slug }}>
+                                            <Badge
+                                                variant="secondary"
+                                                className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
+                                            >
+                                                {tag.name}
+                                            </Badge>
+                                        </Link>
+                                    ))}
+                                </div>
+
+                                {renderPagination()}
+                            </>
+                        ) : (
+                            <Card className="border-gray-100">
+                                <CardContent className="flex h-96 items-center justify-center text-gray-500">
+                                    No tags found. Try adjusting your filters.
+                                </CardContent>
+                            </Card>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </TagFilterContext.Provider>
+    );
+}

--- a/src/context/TagFilterContext.tsx
+++ b/src/context/TagFilterContext.tsx
@@ -1,0 +1,14 @@
+import { createContext, Dispatch, SetStateAction } from 'react';
+import { TagFilters } from '../types/filters';
+
+interface TagFilterContextProps {
+    filters: TagFilters;
+    setFilters: Dispatch<SetStateAction<TagFilters>>;
+}
+
+export const TagFilterContext = createContext<TagFilterContextProps>({
+    filters: {
+        name: '',
+    },
+    setFilters: () => {},
+});

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import type { Tag, PaginatedResponse } from '../types/api';
+
+export interface TagFilters {
+    name: string;
+}
+
+interface UseTagsParams {
+    page?: number;
+    itemsPerPage?: number;
+    filters?: TagFilters;
+    sort?: string;
+    direction?: 'desc' | 'asc';
+}
+
+export const useTags = ({ page = 1, itemsPerPage = 25, filters, sort = 'name', direction = 'asc' }: UseTagsParams = {}) => {
+    return useQuery<PaginatedResponse<Tag>>({
+        queryKey: ['tags', page, itemsPerPage, filters, sort, direction],
+        queryFn: async () => {
+            const params = new URLSearchParams();
+            params.append('page', page.toString());
+            params.append('limit', itemsPerPage.toString());
+            if (filters?.name) params.append('filters[name]', filters.name);
+            if (sort) params.append('sort', sort);
+            if (direction) params.append('direction', direction);
+
+            const { data } = await api.get<PaginatedResponse<Tag>>(`/tags?${params.toString()}`);
+            return data;
+        },
+    });
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,9 +3,11 @@ import { rootRoute } from './routes/root';
 import Events from './components/Events';
 import Entities from './components/Entities';
 import Series from './components/Series';
+import Tags from './components/Tags';
 import { EventDetailRoute } from './routes/event-detail.tsx';
 import { EntityDetailRoute } from './routes/entity-detail.tsx';
 import { SeriesDetailRoute } from './routes/series-detail.tsx';
+import { TagDetailRoute } from './routes/tag-detail.tsx';
 import Account from './routes/account';
 import Calendar from './components/Calendar';
 
@@ -34,6 +36,12 @@ const seriesRoute = createRoute({
     component: Series,
 });
 
+const tagRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/tags',
+    component: Tags,
+});
+
 const accountRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/account',
@@ -52,9 +60,11 @@ const routeTree = rootRoute.addChildren([
     eventRoute,
     entityRoute,
     seriesRoute,
+    tagRoute,
     EventDetailRoute,
     EntityDetailRoute,
     SeriesDetailRoute,
+    TagDetailRoute,
     accountRoute,
     calendarRoute,
 ]);

--- a/src/routes/tag-detail.tsx
+++ b/src/routes/tag-detail.tsx
@@ -1,0 +1,12 @@
+import { createRoute } from '@tanstack/react-router';
+import { rootRoute } from './root';
+import TagDetail from '../components/TagDetail';
+
+export const TagDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/tags/$slug',
+    component: function TagDetailWrapper() {
+        const params = TagDetailRoute.useParams();
+        return <TagDetail slug={params.slug} />;
+    },
+});

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -57,3 +57,7 @@ export interface SeriesFiltersProps {
     };
     onFilterChange: (filters: SeriesFiltersProps['filters']) => void;
 }
+
+export interface TagFilters {
+    name: string;
+}


### PR DESCRIPTION
## Summary
- add Tags page with filters, sorting, and pagination
- add Tag detail page showing related events, entities and series
- allow navigating to tag details from tag badges
- integrate tag routes and menu link

## Testing
- `npm install`
- `npm test` *(fails: process hangs due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685cda015944832292ffcf4d9ea5f181