### PR TITLE
Add login indicator

### DIFF
--- a/src/__tests__/components/MenuBar.test.tsx
+++ b/src/__tests__/components/MenuBar.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import MenuBar from '../../components/MenuBar'
+import { authService } from '../../services/auth.service'
+
+// Mock Link component from react-router to avoid needing RouterProvider
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>
+}))
+
+// Mock route components to avoid API calls if rendered
+vi.mock('../../components/Events', () => ({
+  default: () => <div data-testid="events-component">Events Page</div>
+}))
+vi.mock('../../components/Entities', () => ({
+  default: () => <div data-testid="entities-component">Entities Page</div>
+}))
+vi.mock('../../routes/account', () => ({
+  default: () => <div data-testid="account-component">Account Page</div>
+}))
+vi.mock('../../components/Calendar', () => ({
+  default: () => <div data-testid="calendar-component">Calendar Page</div>
+}))
+
+vi.mock('../../services/auth.service')
+
+const client = new QueryClient()
+
+const renderMenuBar = async () => {
+  render(
+    <QueryClientProvider client={client}>
+      <MenuBar />
+    </QueryClientProvider>
+  )
+  await waitFor(() => {})
+}
+
+describe('MenuBar login indicator', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    localStorage.clear()
+  })
+
+  it('shows login button when not authenticated', async () => {
+    vi.mocked(authService.isAuthenticated).mockReturnValue(false)
+
+    await renderMenuBar()
+
+    expect(screen.getByText('Not logged in')).toBeInTheDocument()
+    expect(screen.getByText('Login / Register')).toBeInTheDocument()
+  })
+
+  it('shows username and account button when authenticated', async () => {
+    vi.mocked(authService.isAuthenticated).mockReturnValue(true)
+    vi.mocked(authService.getCurrentUser).mockResolvedValue({
+      id: 1,
+      username: 'testuser',
+      email: 'test@example.com'
+    })
+
+    await renderMenuBar()
+
+    await waitFor(() => {
+      expect(screen.getByText('Logged in as testuser')).toBeInTheDocument()
+    })
+    expect(screen.getByText('My Account')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/router.test.tsx
+++ b/src/__tests__/router.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { RouterProvider } from '@tanstack/react-router'
 import { router } from '../router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 // Mock the components
 vi.mock('../components/Events', () => ({
@@ -20,10 +21,14 @@ vi.mock('../components/Calendar', () => ({
     default: () => <div data-testid="calendar-component">Calendar Page</div>
 }))
 
+const client = new QueryClient()
+
 describe('Router Configuration', () => {
     it('renders Events component at root path', async () => {
         render(
-            <RouterProvider router={router} />
+            <QueryClientProvider client={client}>
+                <RouterProvider router={router} />
+            </QueryClientProvider>
         )
 
         await waitFor(() => {
@@ -34,7 +39,11 @@ describe('Router Configuration', () => {
     it('renders Events component at /events path', async () => {
         await router.navigate({ to: '/events' })
 
-        render(<RouterProvider router={router} />)
+        render(
+            <QueryClientProvider client={client}>
+                <RouterProvider router={router} />
+            </QueryClientProvider>
+        )
 
         await waitFor(() => {
             expect(screen.getByTestId('events-component')).toBeInTheDocument()
@@ -44,7 +53,11 @@ describe('Router Configuration', () => {
     it('renders Entities component at /entities path', async () => {
         await router.navigate({ to: '/entities' })
 
-        render(<RouterProvider router={router} />)
+        render(
+            <QueryClientProvider client={client}>
+                <RouterProvider router={router} />
+            </QueryClientProvider>
+        )
 
         await waitFor(() => {
             expect(screen.getByTestId('entities-component')).toBeInTheDocument()
@@ -54,7 +67,11 @@ describe('Router Configuration', () => {
     it('renders Account component at /account path', async () => {
         await router.navigate({ to: '/account' })
 
-        render(<RouterProvider router={router} />)
+        render(
+            <QueryClientProvider client={client}>
+                <RouterProvider router={router} />
+            </QueryClientProvider>
+        )
 
         await waitFor(() => {
             expect(screen.getByTestId('account-component')).toBeInTheDocument()
@@ -64,7 +81,11 @@ describe('Router Configuration', () => {
     it('renders Calendar component at /calendar path', async () => {
         await router.navigate({ to: '/calendar' })
 
-        render(<RouterProvider router={router} />)
+        render(
+            <QueryClientProvider client={client}>
+                <RouterProvider router={router} />
+            </QueryClientProvider>
+        )
 
         await waitFor(() => {
             expect(screen.getByTestId('calendar-component')).toBeInTheDocument()

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -23,11 +23,7 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
   return (
     <div className={`flex flex-col items-center justify-center h-full p-4 ${className}`}>
       <h1 className=" xl:block text-2xl font-bold mb-2 text-center">Arcane City</h1>
-      {authService.isAuthenticated() && user ? (
-        <div className="text-sm mb-2">Logged in as {user.username}</div>
-      ) : (
-        <div className="text-sm mb-2 text-gray-400">Not logged in</div>
-      )}
+      <div className="w-full border-b border-gray-200 dark:border-gray-700 my-4"></div>
 
       <nav className="flex flex-col gap-2 items-center">
         <Link to="/events" className="flex items-center gap-2 hover:underline">
@@ -36,7 +32,7 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
         </Link>
         <Link to="/calendar" className="flex items-center gap-2 hover:underline">
           <HiCalendar />
-          <span className=" xl:inline">Calendar</span>
+          <span className=" xl:inline">Event Calendar</span>
         </Link>
         <Link to="/entities" className="flex items-center gap-2 hover:underline">
           <HiOfficeBuilding />
@@ -51,6 +47,7 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
           <span className=" xl:inline">Tags</span>
         </Link>
       </nav>
+      <div className="w-full border-b border-gray-200 dark:border-gray-700 my-4"></div>
       {authService.isAuthenticated() ? (
         <Button asChild className="mt-2 w-full flex items-center justify-center gap-2">
           <Link to="/account">

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
 import { authService } from '../services/auth.service';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { Button } from './ui/button';
@@ -8,6 +9,11 @@ import { Sheet, SheetContent, SheetTrigger } from './ui/sheet';
 
 const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
   const [theme, setTheme] = useLocalStorage<'light' | 'dark'>('theme', 'light');
+  const { data: user } = useQuery({
+    queryKey: ['currentUser'],
+    queryFn: authService.getCurrentUser,
+    enabled: authService.isAuthenticated(),
+  });
 
   const toggleTheme = () => {
     setTheme(theme === 'light' ? 'dark' : 'light');
@@ -16,7 +22,12 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
 
   return (
     <div className={`flex flex-col items-center justify-center h-full p-4 ${className}`}>
-      <h1 className=" xl:block text-2xl font-bold mb-4 text-center">Arcane City</h1>
+      <h1 className=" xl:block text-2xl font-bold mb-2 text-center">Arcane City</h1>
+      {authService.isAuthenticated() && user ? (
+        <div className="text-sm mb-2">Logged in as {user.username}</div>
+      ) : (
+        <div className="text-sm mb-2 text-gray-400">Not logged in</div>
+      )}
 
       <nav className="flex flex-col gap-2 items-center">
         <Link to="/events" className="flex items-center gap-2 hover:underline">
@@ -39,13 +50,22 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
           <HiTag />
           <span className=" xl:inline">Tags</span>
         </Link>
-        {authService.isAuthenticated() && (
-          <Link to="/account" className="flex items-center gap-2 hover:underline">
+      </nav>
+      {authService.isAuthenticated() ? (
+        <Button asChild className="mt-2 w-full flex items-center justify-center gap-2">
+          <Link to="/account">
             <HiUser />
             <span className="lg:inline">My Account</span>
           </Link>
-        )}
-      </nav>
+        </Button>
+      ) : (
+        <Button asChild className="mt-2 w-full flex items-center justify-center gap-2">
+          <Link to="/login">
+            <HiUser />
+            <span className="lg:inline">Login / Register</span>
+          </Link>
+        </Button>
+      )}
       <Button onClick={toggleTheme} className="mt-auto flex items-center gap-2">
         {theme === 'light' ? <HiMoon /> : <HiSun />}
         <span className="hidden xl:inline">

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -48,7 +48,7 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
         </Link>
       </nav>
       <div className="w-full border-b border-gray-200 dark:border-gray-700 my-4"></div>
-      {authService.isAuthenticated() ? (
+      {user ? (
         <Button asChild className="mt-2 w-full flex items-center justify-center gap-2">
           <Link to="/account">
             <HiUser />

--- a/src/components/PhotoGallery.tsx
+++ b/src/components/PhotoGallery.tsx
@@ -21,7 +21,7 @@ export default function PhotoGallery({ fetchUrl }: PhotoGalleryProps) {
             setLoading(true);
             try {
                 const response = await api.get<{ data: PhotoResponse[] }>(fetchUrl);
-                const photoData = (response.data as any).data ?? response.data;
+                const photoData = (response.data as { data: PhotoResponse[] }).data ?? response.data;
                 setPhotos(photoData as PhotoResponse[]);
             } catch (err) {
                 console.error('Error fetching photos:', err);

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,6 +9,8 @@ import { EntityDetailRoute } from './routes/entity-detail.tsx';
 import { SeriesDetailRoute } from './routes/series-detail.tsx';
 import { TagDetailRoute } from './routes/tag-detail.tsx';
 import Account from './routes/account';
+import { LoginRoute } from './routes/login';
+import { RegisterRoute } from './routes/register';
 import Calendar from './components/Calendar';
 
 // Create routes
@@ -67,6 +69,8 @@ const routeTree = rootRoute.addChildren([
     TagDetailRoute,
     accountRoute,
     calendarRoute,
+    LoginRoute,
+    RegisterRoute,
 ]);
 
 // Create and export router

--- a/src/routes/account.tsx
+++ b/src/routes/account.tsx
@@ -1,9 +1,32 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { authService } from '../services/auth.service';
 
 const Account: React.FC = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!authService.isAuthenticated()) {
+      navigate({ to: '/login' });
+    }
+  }, [navigate]);
+
+  const { data: user, isLoading, error } = useQuery({
+    queryKey: ['currentUser'],
+    queryFn: authService.getCurrentUser,
+    enabled: authService.isAuthenticated(),
+  });
+
+  if (isLoading) return <div className="p-4">Loading...</div>;
+  if (error) return <div className="p-4 text-red-500">Failed to load user data.</div>;
+  if (!user) return null;
+
   return (
-    <div>
-      The user is authenticated
+    <div className="p-4 space-y-2">
+      <h2 className="text-xl font-bold">Welcome, {user.username}</h2>
+      <div>Email: {user.email}</div>
+      {/* Personalized content could go here */}
     </div>
   );
 };

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { createRoute, useNavigate } from '@tanstack/react-router';
+import { rootRoute } from './root';
+import { authService } from '../services/auth.service';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+
+const Login: React.FC = () => {
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await authService.login({ username, password });
+      navigate({ to: '/account' });
+    } catch {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      <h2 className="text-xl font-bold">Login</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="username">Username</Label>
+          <Input
+            id="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        {error && <div className="text-red-500 text-sm">{error}</div>}
+        <Button type="submit" className="w-full">Login</Button>
+      </form>
+    </div>
+  );
+};
+
+export const LoginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/login',
+  component: Login,
+});

--- a/src/routes/register.tsx
+++ b/src/routes/register.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { createRoute } from '@tanstack/react-router';
+import { rootRoute } from './root';
+
+const Register: React.FC = () => {
+  return (
+    <div className="max-w-md mx-auto p-4">
+      Registration page coming soon.
+    </div>
+  );
+};
+
+export const RegisterRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/register',
+  component: Register,
+});

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -4,7 +4,12 @@ import { LoginCredentials, User } from '../types/auth';
 
 export const authService = {
     async login(credentials: LoginCredentials) {
-        const { data } = await api.post<{ token: string, user: User }>('/auth/login', credentials);
+        const { username, password } = credentials;
+        const { data } = await api.post<{ token: string }>(
+            '/tokens/create',
+            { token_name: 'arcane-city' },
+            { auth: { username, password } }
+        );
         localStorage.setItem('token', data.token);
         return data;
     },


### PR DESCRIPTION
## Summary
- add login and register routes
- improve account page to fetch user info
- show login status in sidebar with username
- add login/register button when user not authenticated
- update router tests for QueryClientProvider
- test menu bar login indicator

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b9525290483229db3e579b1717327