### PR TITLE
Add personalized For You page

### DIFF
--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { authService } from '../services/auth.service';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { Button } from './ui/button';
-import { HiCalendar, HiOfficeBuilding, HiUser, HiMoon, HiSun, HiMenu, HiCollection, HiTag, HiInformationCircle } from 'react-icons/hi';
+import { HiCalendar, HiOfficeBuilding, HiUser, HiMoon, HiSun, HiMenu, HiCollection, HiTag, HiInformationCircle, HiStar } from 'react-icons/hi';
 import { Sheet, SheetContent, SheetTrigger } from './ui/sheet';
 
 const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
@@ -46,6 +46,12 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
           <HiTag />
           <span className=" xl:inline">Tags</span>
         </Link>
+        {user && (
+          <Link to="/for-you" className="flex items-center gap-2 hover:underline">
+            <HiStar />
+            <span className=" xl:inline">For You</span>
+          </Link>
+        )}
         <Link to="/about" className="flex items-center gap-2 hover:underline">
           <HiInformationCircle />
           <span className=" xl:inline">About</span>

--- a/src/hooks/useForYou.ts
+++ b/src/hooks/useForYou.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { Event } from '../types/api';
+import { authService } from '../services/auth.service';
+
+export interface ForYouResponse {
+  attending_events: Event[];
+  tag_events: Event[];
+  entity_events: Event[];
+}
+
+export const useForYou = () => {
+  return useQuery<ForYouResponse>({
+    queryKey: ['forYou'],
+    queryFn: async () => {
+      const { data } = await api.get<ForYouResponse>('/for-you');
+      return data;
+    },
+    enabled: authService.isAuthenticated(),
+  });
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -13,6 +13,7 @@ import { LoginRoute } from './routes/login';
 import { RegisterRoute } from './routes/register';
 import Calendar from './components/Calendar';
 import { AboutRoute } from './routes/about';
+import { ForYouRoute } from './routes/for-you';
 
 // Create routes
 const indexRoute = createRoute({
@@ -69,6 +70,7 @@ const routeTree = rootRoute.addChildren([
     SeriesDetailRoute,
     TagDetailRoute,
     accountRoute,
+    ForYouRoute,
     calendarRoute,
     AboutRoute,
     LoginRoute,

--- a/src/routes/for-you.tsx
+++ b/src/routes/for-you.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect } from 'react';
+import { createRoute, useNavigate } from '@tanstack/react-router';
+import { rootRoute } from './root';
+import { authService } from '../services/auth.service';
+import { useForYou } from '../hooks/useForYou';
+import EventCardCondensed from '../components/EventCardCondensed';
+
+const ForYou: React.FC = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!authService.isAuthenticated()) {
+      navigate({ to: '/login' });
+    }
+  }, [navigate]);
+
+  const { data, isLoading, error } = useForYou();
+
+  if (!authService.isAuthenticated()) return null;
+  if (isLoading) return <div className="p-4">Loading...</div>;
+  if (error) return <div className="p-4 text-red-500">Failed to load personalized data.</div>;
+  if (!data) return null;
+
+  const allEvents = [
+    ...data.attending_events,
+    ...data.tag_events,
+    ...data.entity_events,
+  ];
+
+  const imageIndexMap = new Map<number, number>();
+  const allImages: Array<{ src: string; alt: string; thumbnail: string }> = [];
+
+  allEvents.forEach((event) => {
+    if (event.primary_photo && event.primary_photo_thumbnail) {
+      imageIndexMap.set(event.id, allImages.length);
+      allImages.push({
+        src: event.primary_photo,
+        alt: event.name,
+        thumbnail: event.primary_photo_thumbnail,
+      });
+    }
+  });
+
+  const renderEvents = (events: typeof allEvents) => (
+    <div className="grid gap-4">
+      {events.map((event) => (
+        <EventCardCondensed
+          key={event.id}
+          event={event}
+          allImages={allImages}
+          imageIndex={imageIndexMap.get(event.id) ?? 0}
+        />
+      ))}
+      {events.length === 0 && <p>No events found.</p>}
+    </div>
+  );
+
+  return (
+    <div className="p-4 space-y-8">
+      <h2 className="text-2xl font-bold">For You</h2>
+
+      <section>
+        <h3 className="text-lg font-semibold mb-2">Events You're Attending</h3>
+        {renderEvents(data.attending_events)}
+      </section>
+
+      <section>
+        <h3 className="text-lg font-semibold mb-2">Events Matching Your Tags</h3>
+        {renderEvents(data.tag_events)}
+      </section>
+
+      <section>
+        <h3 className="text-lg font-semibold mb-2">Events Matching Your Entities</h3>
+        {renderEvents(data.entity_events)}
+      </section>
+    </div>
+  );
+};
+
+export const ForYouRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/for-you',
+  component: ForYou,
+});


### PR DESCRIPTION
## Summary
- add a `useForYou` hook to retrieve personalized data
- add `/for-you` route and page displaying events for the user
- show a new **For You** link in the menu bar when logged in
- register the route in the router

## Testing
- `npm run lint` *(fails: 4 errors, 5 warnings)*
- `npm test --silent` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686624ac05708322b6d17e7a53729d7e