### PR TITLE
Add attend toggle for events

### DIFF
--- a/src/services/events.service.ts
+++ b/src/services/events.service.ts
@@ -1,0 +1,10 @@
+import { api } from '../lib/api';
+
+export const eventsService = {
+  async attend(id: number) {
+    await api.post(`/events/${id}/attend`);
+  },
+  async unattend(id: number) {
+    await api.delete(`/events/${id}/attend`);
+  }
+};

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -18,6 +18,7 @@ export interface Event {
     primary_photo?: string;
     primary_photo_thumbnail?: string;
     is_benefit?: boolean;
+    user_attending?: boolean;
     attending: number;
     like: number;
     photos?: PhotoResponse[];


### PR DESCRIPTION
## Summary
- enable API calls to attend/unattend an event
- show attendance star in both EventCard components when logged in
- track per-event attendance state

## Testing
- `npm test --silent`
- `npm run lint` *(fails: `useTagImage.ts` unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68671c429af083229e607663a4d9cf8d