### PR TITLE
Add attendee star toggle

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -3,12 +3,14 @@ import { api } from '../lib/api';
 import { Event } from '../types/api';
 import { formatDate } from '../lib/utils';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Loader2, Music, CalendarDays, MapPin, DollarSign, Ticket } from 'lucide-react';
+import { Loader2, Music, CalendarDays, MapPin, DollarSign, Ticket, Star } from 'lucide-react';
 import { AgeRestriction } from './AgeRestriction';
 import { EntityBadges } from './EntityBadges';
 import { TagBadges } from './TagBadges';
 import { ImageLightbox } from './ImageLightbox';
 import { useContext } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { authService } from '../services/auth.service';
 import { EventFilterContext } from '../context/EventFilterContext';
 import { useState, useEffect } from 'react';
 
@@ -25,6 +27,36 @@ const EventCard = ({ event, allImages, imageIndex }: EventCardProps) => {
   const [embeds, setEmbeds] = useState<string[]>([]);
   const [embedsLoading, setEmbedsLoading] = useState(false);
   const [embedsError, setEmbedsError] = useState<Error | null>(null);
+  const { data: user } = useQuery({
+    queryKey: ['currentUser'],
+    queryFn: authService.getCurrentUser,
+    enabled: authService.isAuthenticated(),
+  });
+  const [attending, setAttending] = useState(false);
+
+  useEffect(() => {
+    if (user && event.attendees) {
+      setAttending(event.attendees.some((u) => u.id === user.id));
+    }
+  }, [user, event.attendees]);
+
+  const attendMutation = useMutation({
+    mutationFn: async () => {
+      await api.post(`/events/${event.id}/attend`);
+    },
+    onSuccess: () => {
+      setAttending(true);
+    },
+  });
+
+  const unattendMutation = useMutation({
+    mutationFn: async () => {
+      await api.delete(`/events/${event.id}/attend`);
+    },
+    onSuccess: () => {
+      setAttending(false);
+    },
+  });
 
   const handleTagClick = (tagName: string) => {
     setFilters((prevFilters) => ({ ...prevFilters, tag: tagName }));
@@ -40,6 +72,15 @@ const EventCard = ({ event, allImages, imageIndex }: EventCardProps) => {
       to: '/events/$slug',
       params: { slug: event.slug }
     });
+  };
+
+  const handleAttendToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (attending) {
+      unattendMutation.mutate();
+    } else {
+      attendMutation.mutate();
+    }
   };
 
   const placeHolderImage = `${window.location.origin}/event-placeholder.png`;
@@ -92,6 +133,14 @@ const EventCard = ({ event, allImages, imageIndex }: EventCardProps) => {
                     {event.name}
                   </a>
                 </h3>
+                {user && (
+                  <button onClick={handleAttendToggle} aria-label={attending ? 'Unattend' : 'Attend'}>
+                    <Star
+                      className={`h-5 w-5 ${attending ? 'text-yellow-500' : 'text-gray-400'}`}
+                      fill={attending ? 'currentColor' : 'none'}
+                    />
+                  </button>
+                )}
               </div>
               {event.short && (
                 <p className="line-clamp-2 text-sm text-gray-500">{event.short}</p>


### PR DESCRIPTION
## Summary
- allow logged-in users to mark attendance on event cards
- show filled or outline star depending on current attendance status
- POST to `/api/events/{id}/attend` to attend and DELETE to unattend

## Testing
- `npm run lint` *(fails: Unexpected any in useTagImage)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686771a962ec8322b449acaf06b32548