### PR TITLE
Add link icons to badges and wire up Event filters

### DIFF
--- a/src/components/EntityBadges.tsx
+++ b/src/components/EntityBadges.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
+import { Link as RouterLink } from '@tanstack/react-router';
+import { Link as LinkIcon } from 'lucide-react';
 
 interface EntityBadgesProps {
-  entities: Array<{ id: number; name: string }> | undefined;
+  entities: Array<{ id: number; name: string; slug?: string }> | undefined;
   onClick?: (name: string) => void;
 }
 
@@ -14,10 +16,28 @@ export const EntityBadges: React.FC<EntityBadgesProps> = ({ entities, onClick })
         <Badge
           key={entity.id}
           variant="default"
-          className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1"
-          onClick={onClick ? () => onClick(entity.name) : undefined}
+          className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1 flex items-center gap-1"
         >
-          {entity.name}
+          {onClick ? (
+            <span onClick={() => onClick(entity.name)} className="hover:underline">
+              {entity.name}
+            </span>
+          ) : (
+            <RouterLink
+              to="/events"
+              search={{ entity: entity.slug ?? entity.name }}
+              className="hover:underline"
+            >
+              {entity.name}
+            </RouterLink>
+          )}
+          <RouterLink
+            to="/entities/$entitySlug"
+            params={{ entitySlug: entity.slug ?? entity.name }}
+            className="ml-1 text-blue-500 hover:text-blue-800"
+          >
+            <LinkIcon className="h-3 w-3" />
+          </RouterLink>
         </Badge>
       ))}
     </div>

--- a/src/components/EntityCard.tsx
+++ b/src/components/EntityCard.tsx
@@ -3,8 +3,8 @@ import { Entity } from '../types/api';
 import { Card, CardContent } from '@/components/ui/card';
 import MapPin from '@/components/icons/MapPin';
 import Users from '@/components/icons/Users';
-import { Badge } from '@/components/ui/badge';
 import { ImageLightbox } from './ImageLightbox';
+import { TagBadges } from './TagBadges';
 import { useContext } from 'react';
 import { EntityFilterContext } from '../context/EntityFilterContext';
 
@@ -43,9 +43,6 @@ const EntityCard = ({ entity, allImages, imageIndex }: EntityCardProps) => {
     const navigate = useNavigate();
     const { setFilters } = useContext(EntityFilterContext);
 
-    const handleTagClick = (tagName: string) => {
-        setFilters((prevFilters) => ({ ...prevFilters, tag: tagName }));
-    };
 
     const handleClick = (e: React.MouseEvent) => {
         e.preventDefault();
@@ -112,20 +109,7 @@ const EntityCard = ({ entity, allImages, imageIndex }: EntityCardProps) => {
                         </div>
                     )}
                     {entity.tags.length > 0 && (
-                        <div className="space-y-2">
-                            <div className="flex flex-wrap gap-2">
-                                {entity.tags.map((tag) => (
-                                    <Badge
-                                        key={tag.id}
-                                        variant="secondary"
-                                        className="bg-gray-100 text-gray-800 hover:bg-gray-200"
-                                        onClick={() => handleTagClick(tag.name)}
-                                    >
-                                        {tag.name}
-                                    </Badge>
-                                ))}
-                            </div>
-                        </div>
+                        <TagBadges tags={entity.tags} />
                     )}
                 </div>
             </CardContent>

--- a/src/components/EntityCardCondensed.tsx
+++ b/src/components/EntityCardCondensed.tsx
@@ -18,9 +18,6 @@ export default function EntityCardCondensed({ entity, allImages, imageIndex }: E
     const navigate = useNavigate();
     const { setFilters } = useContext(EntityFilterContext);
 
-    const handleTagClick = (tagName: string) => {
-        setFilters(prev => ({ ...prev, tag: tagName }));
-    };
 
     const handleClick = (e: React.MouseEvent) => {
         e.preventDefault();
@@ -77,7 +74,7 @@ export default function EntityCardCondensed({ entity, allImages, imageIndex }: E
                         </div>
                     </CardHeader>
                     <CardContent className="p-4 pt-2">
-                        <TagBadges tags={entity.tags} onClick={handleTagClick} />
+                        <TagBadges tags={entity.tags} />
                     </CardContent>
                 </div>
             </div>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -58,10 +58,6 @@ const EventCard = ({ event, allImages, imageIndex }: EventCardProps) => {
     },
   });
 
-  const handleTagClick = (tagName: string) => {
-    setFilters((prevFilters) => ({ ...prevFilters, tag: tagName }));
-  };
-
   const handleEntityClick = (entityName: string) => {
     setFilters((prevFilters) => ({ ...prevFilters, entity: entityName }));
   };
@@ -220,7 +216,7 @@ const EventCard = ({ event, allImages, imageIndex }: EventCardProps) => {
               onClick={handleEntityClick}
             />
 
-            <TagBadges tags={event.tags} onClick={handleTagClick} />
+            <TagBadges tags={event.tags} />
           </div>
         </CardContent>
       </div>

--- a/src/components/EventCardCondensed.tsx
+++ b/src/components/EventCardCondensed.tsx
@@ -54,9 +54,6 @@ const EventCardCondensed = ({ event, allImages, imageIndex }: EventCardProps) =>
         },
     });
 
-    const handleTagClick = (tagName: string) => {
-        setFilters((prevFilters) => ({ ...prevFilters, tag: tagName }));
-    };
 
     const handleClick = (e: React.MouseEvent) => {
         e.preventDefault();
@@ -188,7 +185,7 @@ const EventCardCondensed = ({ event, allImages, imageIndex }: EventCardProps) =>
 
                             <EntityBadges entities={event.entities} />
 
-                            <TagBadges tags={event.tags} onClick={handleTagClick} />
+                            <TagBadges tags={event.tags} />
                         </div>
                     </CardContent>
                 </div>

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -10,6 +10,8 @@ import { AgeRestriction } from './AgeRestriction';
 import { formatDate } from '../lib/utils';
 import { useState, useEffect } from 'react';
 import PhotoGallery from './PhotoGallery';
+import { TagBadges } from './TagBadges';
+import { EntityBadges } from './EntityBadges';
 
 
 export default function EventDetail({ slug }: { slug: string }) {
@@ -163,6 +165,9 @@ export default function EventDetail({ slug }: { slug: string }) {
                                     </CardContent>
                                 </Card>
                             )}
+
+                            <EntityBadges entities={event.entities} />
+                            <TagBadges tags={event.tags} />
 
 
 

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -47,18 +47,23 @@ export default function Events() {
         return today.toISOString();
     };
 
-    const [filters, setFilters] = useState<EventFilters>({  // Add the type annotation here
-        name: '',
-        venue: '',
-        promoter: '',
-        event_type: '',
-        entity: '',
-        tag: '',
-        start_at: {
-            start: getTodayStart(),
-            end: undefined
-        }
-    });
+    const getInitialFilters = (): EventFilters => {
+        const params = new URLSearchParams(window.location.search);
+        return {
+            name: '',
+            venue: '',
+            promoter: '',
+            event_type: '',
+            entity: params.get('entity') || '',
+            tag: params.get('tag') || '',
+            start_at: {
+                start: getTodayStart(),
+                end: undefined,
+            },
+        };
+    };
+
+    const [filters, setFilters] = useState<EventFilters>(getInitialFilters());
     const [page, setPage] = useState(1);
     // Replace useState with useLocalStorage
     const [itemsPerPage, setItemsPerPage] = useLocalStorage('eventsPerPage', 25);

--- a/src/components/SeriesCard.tsx
+++ b/src/components/SeriesCard.tsx
@@ -21,10 +21,6 @@ const SeriesCard = ({ series, allImages, imageIndex }: SeriesCardProps) => {
   const navigate = useNavigate();
   const { setFilters } = useContext(SeriesFilterContext);
 
-  const handleTagClick = (tagName: string) => {
-    setFilters((prevFilters) => ({ ...prevFilters, tag: tagName }));
-  };
-
   const handleEntityClick = (entityName: string) => {
     setFilters((prevFilters) => ({ ...prevFilters, entity: entityName }));
   };
@@ -119,7 +115,7 @@ const SeriesCard = ({ series, allImages, imageIndex }: SeriesCardProps) => {
 
             <EntityBadges entities={series.entities} onClick={handleEntityClick} />
 
-            <TagBadges tags={series.tags} onClick={handleTagClick} />
+            <TagBadges tags={series.tags} />
           </div>
         </CardContent>
       </div>

--- a/src/components/SeriesCardCondensed.tsx
+++ b/src/components/SeriesCardCondensed.tsx
@@ -20,10 +20,6 @@ export default function SeriesCardCondensed({ series, allImages, imageIndex }: S
     const navigate = useNavigate();
     const { setFilters } = useContext(SeriesFilterContext);
 
-    const handleTagClick = (tagName: string) => {
-        setFilters(prev => ({ ...prev, tag: tagName }));
-    };
-
     const handleEntityClick = (entityName: string) => {
         setFilters(prev => ({ ...prev, entity: entityName }));
     };
@@ -103,7 +99,7 @@ export default function SeriesCardCondensed({ series, allImages, imageIndex }: S
                                 )}
                             </div>
                             <EntityBadges entities={series.entities} onClick={handleEntityClick} />
-                            <TagBadges tags={series.tags} onClick={handleTagClick} />
+                            <TagBadges tags={series.tags} />
                         </div>
                     </CardContent>
                 </div>

--- a/src/components/TagBadges.tsx
+++ b/src/components/TagBadges.tsx
@@ -1,36 +1,37 @@
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
-import { Link } from '@tanstack/react-router';
+import { Link as RouterLink } from '@tanstack/react-router';
+import { Link as LinkIcon } from 'lucide-react';
 
 interface TagBadgesProps {
   tags: Array<{ id: number; name: string; slug?: string }> | undefined;
-  onClick?: (name: string) => void;
 }
 
-export const TagBadges: React.FC<TagBadgesProps> = ({ tags, onClick }) => {
+export const TagBadges: React.FC<TagBadgesProps> = ({ tags }) => {
   if (!tags || tags.length === 0) return null;
   return (
     <div className="flex flex-wrap gap-2">
       {tags.map(tag => (
-        onClick ? (
-          <Badge
-            key={tag.id}
-            variant="secondary"
-            className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
-            onClick={() => onClick(tag.name)}
+        <Badge
+          key={tag.id}
+          variant="secondary"
+          className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer flex items-center gap-1"
+        >
+          <RouterLink
+            to="/events"
+            search={{ tag: tag.slug ?? tag.name }}
+            className="hover:underline"
           >
             {tag.name}
-          </Badge>
-        ) : (
-          <Link key={tag.id} to="/tags/$slug" params={{ slug: tag.slug ?? tag.name }}>
-            <Badge
-              variant="secondary"
-              className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
-            >
-              {tag.name}
-            </Badge>
-          </Link>
-        )
+          </RouterLink>
+          <RouterLink
+            to="/tags/$slug"
+            params={{ slug: tag.slug ?? tag.name }}
+            className="ml-1 text-gray-500 hover:text-gray-900"
+          >
+            <LinkIcon className="h-3 w-3" />
+          </RouterLink>
+        </Badge>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- update `TagBadges` so tag names link to the events page filtered by the tag
- add link icons linking to tag detail pages
- update `EntityBadges` with link icons and event page links
- parse query parameters in the events page for initial filters
- display tag and entity badges on the event detail page
- adjust card components to use new badges

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6869b1f1c1208322a223fcad29ba3712