### PR TITLE
Show event relations

### DIFF
--- a/src/components/EntityBadges.tsx
+++ b/src/components/EntityBadges.tsx
@@ -22,7 +22,7 @@ export const EntityBadges: React.FC<EntityBadgesProps> = ({ entities, onClick })
             {entity.name}
           </Badge>
         ) : (
-          <Link key={entity.id} to="/entities/$slug" params={{ slug: entity.slug ?? entity.name }}>
+          <Link key={entity.id} to="/entities/$entitySlug" params={{ entitySlug: entity.slug ?? entity.name }}>
             <Badge
               variant="default"
               className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1"

--- a/src/components/EntityBadges.tsx
+++ b/src/components/EntityBadges.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
+import { Link } from '@tanstack/react-router';
 
 interface EntityBadgesProps {
-  entities: Array<{ id: number; name: string }> | undefined;
+  entities: Array<{ id: number; name: string; slug?: string }> | undefined;
   onClick?: (name: string) => void;
 }
 
@@ -11,14 +12,25 @@ export const EntityBadges: React.FC<EntityBadgesProps> = ({ entities, onClick })
   return (
     <div className="flex flex-wrap gap-2 mt-2">
       {entities.map(entity => (
-        <Badge
-          key={entity.id}
-          variant="default"
-          className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1"
-          onClick={onClick ? () => onClick(entity.name) : undefined}
-        >
-          {entity.name}
-        </Badge>
+        onClick ? (
+          <Badge
+            key={entity.id}
+            variant="default"
+            className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1 cursor-pointer"
+            onClick={() => onClick(entity.name)}
+          >
+            {entity.name}
+          </Badge>
+        ) : (
+          <Link key={entity.id} to="/entities/$slug" params={{ slug: entity.slug ?? entity.name }}>
+            <Badge
+              variant="default"
+              className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1"
+            >
+              {entity.name}
+            </Badge>
+          </Link>
+        )
       ))}
     </div>
   );

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -10,6 +10,8 @@ import { AgeRestriction } from './AgeRestriction';
 import { formatDate } from '../lib/utils';
 import { useState, useEffect } from 'react';
 import PhotoGallery from './PhotoGallery';
+import { EntityBadges } from './EntityBadges';
+import { TagBadges } from './TagBadges';
 
 
 export default function EventDetail({ slug }: { slug: string }) {
@@ -162,6 +164,20 @@ export default function EventDetail({ slug }: { slug: string }) {
                                         <div dangerouslySetInnerHTML={{ __html: formattedDescription }} />
                                     </CardContent>
                                 </Card>
+                            )}
+
+                            {event.entities && event.entities.length > 0 && (
+                                <div>
+                                    <h3 className="font-semibold mb-2">Entities</h3>
+                                    <EntityBadges entities={event.entities} />
+                                </div>
+                            )}
+
+                            {event.tags && event.tags.length > 0 && (
+                                <div>
+                                    <h3 className="font-semibold mb-2">Tags</h3>
+                                    <TagBadges tags={event.tags} />
+                                </div>
                             )}
 
 

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -168,14 +168,12 @@ export default function EventDetail({ slug }: { slug: string }) {
 
                             {event.entities && event.entities.length > 0 && (
                                 <div>
-                                    <h3 className="font-semibold mb-2">Entities</h3>
                                     <EntityBadges entities={event.entities} />
                                 </div>
                             )}
 
                             {event.tags && event.tags.length > 0 && (
                                 <div>
-                                    <h3 className="font-semibold mb-2">Tags</h3>
                                     <TagBadges tags={event.tags} />
                                 </div>
                             )}


### PR DESCRIPTION
## Summary
- make entity badges optionally linkable
- list entities and tags on the event detail page

## Testing
- `npx vitest` *(fails: Need to install vitest)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869bc3f0530832287e3e7ce40b4c0e8