### PR TITLE
Add event list to entity page

### DIFF
--- a/src/components/EntityDetail.tsx
+++ b/src/components/EntityDetail.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Loader2, ArrowLeft, MapPin, Users, Music } from 'lucide-react';
 import { useState, useEffect } from 'react';
+import EntityEvents from './EntityEvents';
 
 export default function EntityDetail({ entitySlug }: { entitySlug: string }) {
     const [embeds, setEmbeds] = useState<string[]>([]);
@@ -200,6 +201,7 @@ export default function EntityDetail({ entitySlug }: { entitySlug: string }) {
                             )}
                         </div>
                     </div>
+                    <EntityEvents entitySlug={entity.slug} />
                 </div>
             </div>
         </div>

--- a/src/components/EntityEvents.tsx
+++ b/src/components/EntityEvents.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { useEvents } from '../hooks/useEvents';
+import EventCard from './EventCard';
+import { Pagination } from './Pagination';
+import { Loader2 } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface EntityEventsProps {
+    entitySlug: string;
+}
+
+const sortOptions = [
+    { value: 'start_at', label: 'Date' },
+    { value: 'name', label: 'Name' },
+    { value: 'venue_id', label: 'Venue' },
+    { value: 'promoter_id', label: 'Promoter' },
+    { value: 'event_type_id', label: 'Type' },
+    { value: 'created_at', label: 'Recently Added' },
+];
+
+export default function EntityEvents({ entitySlug }: EntityEventsProps) {
+    const [page, setPage] = useState(1);
+    const [itemsPerPage, setItemsPerPage] = useState(10);
+    const [sort, setSort] = useState('start_at');
+    const [direction, setDirection] = useState<'asc' | 'desc'>('desc');
+
+    const { data, isLoading, error } = useEvents({
+        filters: { entity: entitySlug },
+        page,
+        itemsPerPage,
+        sort,
+        direction,
+    });
+
+    const allEventImages =
+        data?.data
+            .filter((event) => event.primary_photo && event.primary_photo_thumbnail)
+            .map((event) => ({
+                src: event.primary_photo!,
+                alt: event.name,
+                thumbnail: event.primary_photo_thumbnail,
+            })) ?? [];
+
+    const handlePageChange = (newPage: number) => {
+        setPage(newPage);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    const handleItemsPerPageChange = (count: number) => {
+        setItemsPerPage(count);
+        setPage(1);
+    };
+
+    const renderPagination = () => {
+        if (!data) return null;
+        return (
+            <Pagination
+                currentPage={page}
+                totalPages={data.last_page}
+                onPageChange={handlePageChange}
+                itemCount={data.data.length}
+                totalItems={data.total}
+                itemsPerPage={itemsPerPage}
+                onItemsPerPageChange={handleItemsPerPageChange}
+                sort={sort}
+                setSort={setSort}
+                direction={direction}
+                setDirection={setDirection}
+                sortOptions={sortOptions}
+            />
+        );
+    };
+
+    if (error) {
+        return (
+            <Alert variant="destructive">
+                <AlertDescription>
+                    There was an error loading events. Please try again later.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    if (isLoading) {
+        return (
+            <div className="flex h-96 items-center justify-center" role="status">
+                <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+            </div>
+        );
+    }
+
+    if (!data || data.data.length === 0) {
+        return (
+            <Card className="border-gray-100">
+                <CardContent className="flex h-96 items-center justify-center text-gray-500">
+                    No events found.
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <div className="space-y-6 mt-8">
+            <h2 className="text-2xl font-semibold">Events</h2>
+            {renderPagination()}
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-3 3xl:grid-cols-4">
+                {data.data.map((event) => (
+                    <EventCard
+                        key={event.slug}
+                        event={event}
+                        allImages={allEventImages}
+                        imageIndex={allEventImages.findIndex((img) => img.src === event.primary_photo)}
+                    />
+                ))}
+            </div>
+            {renderPagination()}
+        </div>
+    );
+}
+


### PR DESCRIPTION
## Summary
- add an `EntityEvents` component to list events for an entity
- show `EntityEvents` at the bottom of the entity detail page with pagination and sorting

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in src/hooks/useTagImage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6869d68da8c88322bbb25c6d6d47103d