### PR TITLE
Add navigation links for tag/entity badges

### DIFF
--- a/src/components/EntityBadges.tsx
+++ b/src/components/EntityBadges.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
+import { Link as LinkIcon } from 'lucide-react';
 
 interface EntityBadgesProps {
   entities: Array<{ id: number; name: string; slug?: string }> | undefined;
@@ -8,29 +9,35 @@ interface EntityBadgesProps {
 }
 
 export const EntityBadges: React.FC<EntityBadgesProps> = ({ entities, onClick }) => {
+  const navigate = useNavigate();
   if (!entities || entities.length === 0) return null;
+
+  const handleNameClick = (name: string) => {
+    if (onClick) {
+      onClick(name);
+    } else {
+      navigate({ to: '/events', search: { entity: name } });
+    }
+  };
+
   return (
     <div className="flex flex-wrap gap-2 mt-2">
       {entities.map(entity => (
-        onClick ? (
-          <Badge
-            key={entity.id}
-            variant="default"
-            className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1 cursor-pointer"
-            onClick={() => onClick(entity.name)}
+        <Badge
+          key={entity.id}
+          variant="default"
+          className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1 flex items-center gap-1 cursor-pointer"
+        >
+          <span onClick={() => handleNameClick(entity.name)}>{entity.name}</span>
+          <Link
+            to="/entities/$entitySlug"
+            params={{ entitySlug: entity.slug ?? entity.name }}
+            className="ml-1 text-blue-600 hover:text-blue-800"
+            onClick={e => e.stopPropagation()}
           >
-            {entity.name}
-          </Badge>
-        ) : (
-          <Link key={entity.id} to="/entities/$entitySlug" params={{ entitySlug: entity.slug ?? entity.name }}>
-            <Badge
-              variant="default"
-              className="bg-blue-100 text-blue-800 hover:bg-blue-200 px-3 py-1"
-            >
-              {entity.name}
-            </Badge>
+            <LinkIcon className="h-3 w-3" />
           </Link>
-        )
+        </Badge>
       ))}
     </div>
   );

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -12,8 +12,6 @@ import { useState, useEffect } from 'react';
 import PhotoGallery from './PhotoGallery';
 import { EntityBadges } from './EntityBadges';
 import { TagBadges } from './TagBadges';
-import { useContext } from 'react';
-import { EventFilterContext } from '../context/EventFilterContext';
 
 
 export default function EventDetail({ slug }: { slug: string }) {
@@ -57,16 +55,6 @@ export default function EventDetail({ slug }: { slug: string }) {
         }
     };
 
-    const { setFilters } = useContext(EventFilterContext);
-
-
-    const handleTagClick = (tagName: string) => {
-        setFilters((prevFilters) => ({ ...prevFilters, tag: tagName }));
-    };
-
-    const handleEntityClick = (entityName: string) => {
-        setFilters((prevFilters) => ({ ...prevFilters, entity: entityName }));
-    };
 
     // Fetch the event data
     const { data: event, isLoading, error } = useQuery<Event>({
@@ -250,15 +238,9 @@ export default function EventDetail({ slug }: { slug: string }) {
                                             )}
                                         </div>
 
-                                        <EntityBadges
-                                            entities={event.entities}
-                                            onClick={handleEntityClick}
-                                        />
+                                        <EntityBadges entities={event.entities} />
 
-                                        <TagBadges
-                                            tags={event.tags}
-                                            onClick={handleTagClick}
-                                        />
+                                        <TagBadges tags={event.tags} />
                                     </div>
                                 </CardContent>
                             </Card>

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -59,6 +59,18 @@ export default function Events() {
             end: undefined
         }
     });
+
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search);
+        const tag = params.get('tag');
+        const entity = params.get('entity');
+        if (tag) {
+            setFilters(prev => ({ ...prev, tag }));
+        }
+        if (entity) {
+            setFilters(prev => ({ ...prev, entity }));
+        }
+    }, []);
     const [page, setPage] = useState(1);
     // Replace useState with useLocalStorage
     const [itemsPerPage, setItemsPerPage] = useLocalStorage('eventsPerPage', 25);

--- a/src/components/TagBadges.tsx
+++ b/src/components/TagBadges.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
+import { Link as LinkIcon } from 'lucide-react';
 
 interface TagBadgesProps {
   tags: Array<{ id: number; name: string; slug?: string }> | undefined;
@@ -8,29 +9,35 @@ interface TagBadgesProps {
 }
 
 export const TagBadges: React.FC<TagBadgesProps> = ({ tags, onClick }) => {
+  const navigate = useNavigate();
   if (!tags || tags.length === 0) return null;
+
+  const handleNameClick = (name: string) => {
+    if (onClick) {
+      onClick(name);
+    } else {
+      navigate({ to: '/events', search: { tag: name } });
+    }
+  };
+
   return (
     <div className="flex flex-wrap gap-2">
       {tags.map(tag => (
-        onClick ? (
-          <Badge
-            key={tag.id}
-            variant="secondary"
-            className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
-            onClick={() => onClick(tag.name)}
+        <Badge
+          key={tag.id}
+          variant="secondary"
+          className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer flex items-center gap-1"
+        >
+          <span onClick={() => handleNameClick(tag.name)}>{tag.name}</span>
+          <Link
+            to="/tags/$slug"
+            params={{ slug: tag.slug ?? tag.name }}
+            className="ml-1 text-gray-500 hover:text-gray-700"
+            onClick={e => e.stopPropagation()}
           >
-            {tag.name}
-          </Badge>
-        ) : (
-          <Link key={tag.id} to="/tags/$slug" params={{ slug: tag.slug ?? tag.name }}>
-            <Badge
-              variant="secondary"
-              className="bg-gray-100 text-gray-800 hover:bg-gray-200 cursor-pointer"
-            >
-              {tag.name}
-            </Badge>
+            <LinkIcon className="h-3 w-3" />
           </Link>
-        )
+        </Badge>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- add navigation behavior to `TagBadges` and `EntityBadges`
- parse query params on events page to set filters
- update `EventDetail` to use new badge behavior

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686b631306c883228181634b274cdae6