### PR TITLE
Add follow buttons

### DIFF
--- a/src/components/EntityDetail.tsx
+++ b/src/components/EntityDetail.tsx
@@ -1,10 +1,10 @@
 import { Link } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { Entity } from '../types/api';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Loader2, ArrowLeft, MapPin, Users, Music } from 'lucide-react';
+import { Loader2, ArrowLeft, MapPin, Users, Music, Star } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import PhotoGallery from './PhotoGallery';
 import EntityEvents from './EntityEvents';
@@ -30,6 +30,40 @@ export default function EntityDetail({ entitySlug }: { entitySlug: string }) {
         queryFn: authService.getCurrentUser,
         enabled: authService.isAuthenticated(),
     });
+
+    const [following, setFollowing] = useState(false);
+
+    useEffect(() => {
+        if (user) {
+            setFollowing(user.followed_entities.some(e => e.slug === entitySlug));
+        }
+    }, [user, entitySlug]);
+
+    const followMutation = useMutation({
+        mutationFn: async () => {
+            await api.post(`/entities/${entitySlug}/follow`);
+        },
+        onSuccess: () => {
+            setFollowing(true);
+        },
+    });
+
+    const unfollowMutation = useMutation({
+        mutationFn: async () => {
+            await api.post(`/entities/${entitySlug}/unfollow`);
+        },
+        onSuccess: () => {
+            setFollowing(false);
+        },
+    });
+
+    const handleFollowToggle = () => {
+        if (following) {
+            unfollowMutation.mutate();
+        } else {
+            followMutation.mutate();
+        }
+    };
 
     // Fetch event embeds after the entity detail is loaded
     useEffect(() => {
@@ -94,7 +128,14 @@ export default function EntityDetail({ entitySlug }: { entitySlug: string }) {
                         {/* Main Content */}
                         <div className="space-y-6">
                             <div>
-                                <h1 className="text-4xl font-bold text-gray-900 mb-4">{entity.name}</h1>
+                                <div className="flex items-start justify-between">
+                                    <h1 className="text-4xl font-bold text-gray-900 mb-4">{entity.name}</h1>
+                                    {user && (
+                                        <button onClick={handleFollowToggle} aria-label={following ? 'Unfollow' : 'Follow'}>
+                                            <Star className={`h-6 w-6 ${following ? 'text-yellow-500' : 'text-gray-400'}`} fill={following ? 'currentColor' : 'none'} />
+                                        </button>
+                                    )}
+                                </div>
                                 {entity.short && (
                                     <p className="text-xl text-gray-600">{entity.short}</p>
                                 )}

--- a/src/components/SeriesDetail.tsx
+++ b/src/components/SeriesDetail.tsx
@@ -5,6 +5,7 @@ import { Series } from '../types/api';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Loader2, ArrowLeft, CalendarDays, MapPin, DollarSign, Ticket, Star } from 'lucide-react';
+import { useState, useEffect } from 'react';
 import PhotoGallery from './PhotoGallery';
 import PhotoDropzone from './PhotoDropzone';
 import { AgeRestriction } from './AgeRestriction';

--- a/src/components/SeriesDetail.tsx
+++ b/src/components/SeriesDetail.tsx
@@ -1,10 +1,10 @@
 import { Link } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { Series } from '../types/api';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Loader2, ArrowLeft, CalendarDays, MapPin, DollarSign, Ticket } from 'lucide-react';
+import { Loader2, ArrowLeft, CalendarDays, MapPin, DollarSign, Ticket, Star } from 'lucide-react';
 import PhotoGallery from './PhotoGallery';
 import PhotoDropzone from './PhotoDropzone';
 import { AgeRestriction } from './AgeRestriction';
@@ -19,6 +19,40 @@ export default function SeriesDetail({ slug }: { slug: string }) {
         queryFn: authService.getCurrentUser,
         enabled: authService.isAuthenticated(),
     });
+
+    const [following, setFollowing] = useState(false);
+
+    useEffect(() => {
+        if (user) {
+            setFollowing(user.followed_series.some(s => s.slug === slug));
+        }
+    }, [user, slug]);
+
+    const followMutation = useMutation({
+        mutationFn: async () => {
+            await api.post(`/series/${slug}/follow`);
+        },
+        onSuccess: () => {
+            setFollowing(true);
+        },
+    });
+
+    const unfollowMutation = useMutation({
+        mutationFn: async () => {
+            await api.post(`/series/${slug}/unfollow`);
+        },
+        onSuccess: () => {
+            setFollowing(false);
+        },
+    });
+
+    const handleFollowToggle = () => {
+        if (following) {
+            unfollowMutation.mutate();
+        } else {
+            followMutation.mutate();
+        }
+    };
 
     // Fetch the series data
     const { data: series, isLoading, error, refetch } = useQuery<Series>({
@@ -70,7 +104,14 @@ export default function SeriesDetail({ slug }: { slug: string }) {
                         {/* Main Content */}
                         <div className="space-y-6">
                             <div>
-                                <h1 className="text-4xl font-bold text-gray-900 mb-4">{series.name}</h1>
+                                <div className="flex items-start justify-between">
+                                    <h1 className="text-4xl font-bold text-gray-900 mb-4">{series.name}</h1>
+                                    {user && (
+                                        <button onClick={handleFollowToggle} aria-label={following ? 'Unfollow' : 'Follow'}>
+                                            <Star className={`h-6 w-6 ${following ? 'text-yellow-500' : 'text-gray-400'}`} fill={following ? 'currentColor' : 'none'} />
+                                        </button>
+                                    )}
+                                </div>
                                 {series.short && (
                                     <p className="text-xl text-gray-600">{series.short}</p>
                                 )}


### PR DESCRIPTION
## Summary
- show follow/unfollow button on entity cards
- add follow toggle to entity detail
- show follow/unfollow button on series cards
- add follow toggle to series detail

## Testing
- `npm run lint` *(fails: Unexpected any in useTagImage.ts)*
- `npm test` *(fails: No QueryClient set)*

------
https://chatgpt.com/codex/tasks/task_e_6879f5e5a5088322bfa3a87385b6c400