### PR TITLE
Implement user registration page

### DIFF
--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { createRoute, useNavigate } from '@tanstack/react-router';
+import { createRoute, useNavigate, Link } from '@tanstack/react-router';
 import { rootRoute } from './root';
 import { authService } from '../services/auth.service';
 import { Button } from '../components/ui/button';
@@ -46,6 +46,9 @@ const Login: React.FC = () => {
         {error && <div className="text-red-500 text-sm">{error}</div>}
         <Button type="submit" className="w-full">Login</Button>
       </form>
+      <Button asChild variant="link" className="w-full">
+        <Link to="/register">Need an account? Register</Link>
+      </Button>
     </div>
   );
 };

--- a/src/routes/register.tsx
+++ b/src/routes/register.tsx
@@ -6,26 +6,57 @@ import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 
+interface FieldErrors {
+  name?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  general?: string;
+}
+
 const Register: React.FC = () => {
   const navigate = useNavigate();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [error, setError] = useState('');
+  const [errors, setErrors] = useState<FieldErrors>({});
+
+  const validate = (): FieldErrors => {
+    const validationErrors: FieldErrors = {};
+    if (name.length < 6 || name.length > 60) {
+      validationErrors.name = 'Name must be between 6 and 60 characters';
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (
+      email.length < 6 ||
+      email.length > 60 ||
+      !emailRegex.test(email)
+    ) {
+      validationErrors.email = 'Enter a valid email address';
+    }
+    if (password.length < 12 || password.length > 60) {
+      validationErrors.password = 'Password must be between 12 and 60 characters';
+    }
+    if (password !== confirmPassword) {
+      validationErrors.confirmPassword = 'Passwords do not match';
+    }
+    return validationErrors;
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (password !== confirmPassword) {
-      setError('Passwords do not match');
+    const validationErrors = validate();
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
       return;
     }
-    setError('');
+    setErrors({});
     try {
       await userService.createUser({ name, email, password });
       navigate({ to: '/login' });
     } catch {
-      setError('Registration failed');
+      setErrors({ general: 'Registration failed' });
     }
   };
 
@@ -36,20 +67,24 @@ const Register: React.FC = () => {
         <div className="space-y-2">
           <Label htmlFor="name">Name</Label>
           <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+          {errors.name && <div className="text-red-500 text-sm">{errors.name}</div>}
         </div>
         <div className="space-y-2">
           <Label htmlFor="email">Email</Label>
           <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+          {errors.email && <div className="text-red-500 text-sm">{errors.email}</div>}
         </div>
         <div className="space-y-2">
           <Label htmlFor="password">Password</Label>
           <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+          {errors.password && <div className="text-red-500 text-sm">{errors.password}</div>}
         </div>
         <div className="space-y-2">
           <Label htmlFor="confirm">Confirm Password</Label>
           <Input id="confirm" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} />
+          {errors.confirmPassword && <div className="text-red-500 text-sm">{errors.confirmPassword}</div>}
         </div>
-        {error && <div className="text-red-500 text-sm">{error}</div>}
+        {errors.general && <div className="text-red-500 text-sm">{errors.general}</div>}
         <Button type="submit" className="w-full">Register</Button>
       </form>
     </div>

--- a/src/routes/register.tsx
+++ b/src/routes/register.tsx
@@ -1,11 +1,57 @@
-import React from 'react';
-import { createRoute } from '@tanstack/react-router';
+import React, { useState } from 'react';
+import { createRoute, useNavigate } from '@tanstack/react-router';
 import { rootRoute } from './root';
+import { userService } from '../services/user.service';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
 
 const Register: React.FC = () => {
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+    setError('');
+    try {
+      await userService.createUser({ name, email, password });
+      navigate({ to: '/login' });
+    } catch {
+      setError('Registration failed');
+    }
+  };
+
   return (
-    <div className="max-w-md mx-auto p-4">
-      Registration page coming soon.
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      <h2 className="text-xl font-bold">Register</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="confirm">Confirm Password</Label>
+          <Input id="confirm" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} />
+        </div>
+        {error && <div className="text-red-500 text-sm">{error}</div>}
+        <Button type="submit" className="w-full">Register</Button>
+      </form>
     </div>
   );
 };

--- a/src/routes/register.tsx
+++ b/src/routes/register.tsx
@@ -35,8 +35,8 @@ const Register: React.FC = () => {
     ) {
       validationErrors.email = 'Enter a valid email address';
     }
-    if (password.length < 12 || password.length > 60) {
-      validationErrors.password = 'Password must be between 12 and 60 characters';
+    if (password.length < 8 || password.length > 60) {
+      validationErrors.password = 'Password must be between 8 and 60 characters';
     }
     if (password !== confirmPassword) {
       validationErrors.confirmPassword = 'Passwords do not match';

--- a/src/routes/register.tsx
+++ b/src/routes/register.tsx
@@ -37,7 +37,7 @@ const Register: React.FC = () => {
     ) {
       validationErrors.email = 'Enter a valid email address';
     }
-    if (password.length < 12 || password.length > 60) {
+    if (password.length < 8 || password.length > 60) {
       validationErrors.password = 'Password must be between 12 and 60 characters';
     }
     if (password !== confirmPassword) {

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,0 +1,14 @@
+import { api } from '../lib/api';
+
+export interface CreateUserRequest {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export const userService = {
+  async createUser(payload: CreateUserRequest) {
+    const { data } = await api.post('/users', payload);
+    return data;
+  },
+};


### PR DESCRIPTION
## Summary
- add new user service for creating accounts
- implement registration page with form validation
- add link from login page to registration page

## Testing
- `npm test` *(fails: No QueryClient set)*

------
https://chatgpt.com/codex/tasks/task_e_687c2ef3bd1c8322bc9923415737d91e