### PR TITLE
Add registration success page

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -13,6 +13,7 @@ import { EntityCreateRoute } from './routes/entity-create.tsx';
 import Account from './routes/account';
 import { LoginRoute } from './routes/login';
 import { RegisterRoute } from './routes/register';
+import { RegisterSuccessRoute } from './routes/register-success';
 import Calendar from './components/Calendar';
 import { AboutRoute } from './routes/about';
 
@@ -77,6 +78,7 @@ const routeTree = rootRoute.addChildren([
     AboutRoute,
     LoginRoute,
     RegisterRoute,
+    RegisterSuccessRoute,
 ]);
 
 // Create and export router

--- a/src/routes/register-success.tsx
+++ b/src/routes/register-success.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { createRoute, Link, useSearch } from '@tanstack/react-router';
+import { rootRoute } from './root';
+import { Button } from '../components/ui/button';
+
+interface SuccessSearch {
+  name?: string;
+  email?: string;
+}
+
+const RegisterSuccess: React.FC = () => {
+  const { name, email } = useSearch({ from: '/register/success' }) as SuccessSearch;
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      <h2 className="text-xl font-bold">Registration Successful</h2>
+      {name && (
+        <p>
+          <strong>Name:</strong> {name}
+        </p>
+      )}
+      {email && (
+        <p>
+          <strong>Email:</strong> {email}
+        </p>
+      )}
+      <p>Please check your email for a message to activate your account.</p>
+      <p>
+        Once activated, log in to start adding and following events, entities, series and more.
+      </p>
+      <Button asChild className="w-full">
+        <Link to="/login">Log In</Link>
+      </Button>
+    </div>
+  );
+};
+
+export const RegisterSuccessRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/register/success',
+  component: RegisterSuccess,
+});

--- a/src/routes/register.tsx
+++ b/src/routes/register.tsx
@@ -56,7 +56,7 @@ const Register: React.FC = () => {
     setErrors({});
     try {
       await userService.createUser({ name, email, password });
-      navigate({ to: '/login' });
+      navigate({ to: '/register/success', search: { name, email } });
     } catch (err) {
       const axiosErr = err as AxiosError<{ message?: string; errors?: FieldErrors }>;
       if (axiosErr.response && axiosErr.response.status >= 400 && axiosErr.response.status < 500) {

--- a/src/routes/register.tsx
+++ b/src/routes/register.tsx
@@ -38,7 +38,7 @@ const Register: React.FC = () => {
       validationErrors.email = 'Enter a valid email address';
     }
     if (password.length < 8 || password.length > 60) {
-      validationErrors.password = 'Password must be between 12 and 60 characters';
+      validationErrors.password = 'Password must be between 8 and 60 characters';
     }
     if (password !== confirmPassword) {
       validationErrors.confirmPassword = 'Passwords do not match';


### PR DESCRIPTION
## Summary
- show registration success page that reminds user to check email
- redirect to success page when registration is complete
- register new route in router

## Testing
- `npm test` *(fails: No QueryClient set, use QueryClientProvider to set one)*

------
https://chatgpt.com/codex/tasks/task_e_687e98c1023c8322af9ed5c0b4b2f91c