### PR TITLE
Add Users listing and detail pages

### DIFF
--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { authService } from '../services/auth.service';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { Button } from './ui/button';
-import { HiCalendar, HiOfficeBuilding, HiUser, HiMoon, HiSun, HiMenu, HiCollection, HiTag, HiInformationCircle, HiQuestionMarkCircle } from 'react-icons/hi';
+import { HiCalendar, HiOfficeBuilding, HiUser, HiUserGroup, HiMoon, HiSun, HiMenu, HiCollection, HiTag, HiInformationCircle, HiQuestionMarkCircle } from 'react-icons/hi';
 import { Sheet, SheetContent, SheetTrigger } from './ui/sheet';
 
 const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
@@ -54,6 +54,10 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
         <Link to="/tags" className="flex items-center gap-2 hover:underline">
           <HiTag />
           <span className=" xl:inline">Tags</span>
+        </Link>
+        <Link to="/users" className="flex items-center gap-2 hover:underline">
+          <HiUserGroup />
+          <span className=" xl:inline">Users</span>
         </Link>
 
         <div className="w-full border-b border-gray-200 dark:border-gray-700 my-4"></div>

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -1,0 +1,41 @@
+import { useNavigate } from '@tanstack/react-router';
+import type { User } from '../types/auth';
+import { Card, CardContent } from '@/components/ui/card';
+
+interface UserCardProps {
+    user: User;
+}
+
+export default function UserCard({ user }: UserCardProps) {
+    const navigate = useNavigate();
+    const placeholder = `${window.location.origin}/event-placeholder.png`;
+    const photo = user.photos && user.photos.length > 0 ? user.photos[0].thumbnail_path : null;
+
+    const handleClick = (e: React.MouseEvent) => {
+        e.preventDefault();
+        navigate({
+            to: '/users/$id',
+            params: { id: String(user.id) }
+        });
+    };
+
+    return (
+        <Card className="hover:shadow-md transition-shadow">
+            <CardContent className="p-4 flex flex-col items-center space-y-2">
+                <div className="h-24 w-full bg-gray-200 rounded overflow-hidden">
+                    <img
+                        src={photo || placeholder}
+                        alt={user.name}
+                        className="h-24 w-full object-cover"
+                    />
+                </div>
+                <h2 className="text-lg font-semibold text-center">
+                    <a href={`/users/${user.id}`} onClick={handleClick} className="hover:text-primary transition-colors">
+                        {user.name}
+                    </a>
+                </h2>
+                <p className="text-sm text-gray-600">{user.email}</p>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/components/UserDetail.tsx
+++ b/src/components/UserDetail.tsx
@@ -1,0 +1,60 @@
+import { Link } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import type { User } from '../types/auth';
+import { Button } from '@/components/ui/button';
+import { Loader2, ArrowLeft } from 'lucide-react';
+
+export default function UserDetail({ id }: { id: string }) {
+    const { data: user, isLoading, error } = useQuery<User>({
+        queryKey: ['user', id],
+        queryFn: async () => {
+            const { data } = await api.get<User>(`/users/${id}`);
+            return data;
+        },
+    });
+
+    if (isLoading) {
+        return (
+            <div className="flex h-96 items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+            </div>
+        );
+    }
+
+    if (error || !user) {
+        return (
+            <div className="text-center text-red-500">Error loading user. Please try again later.</div>
+        );
+    }
+
+    const photo = user.photos && user.photos.length > 0 ? user.photos[0].thumbnail_path : null;
+    const placeholder = `${window.location.origin}/event-placeholder.png`;
+
+    return (
+        <div className="min-h-screen">
+            <div className="mx-auto px-6 py-8 max-w-[2400px] space-y-6">
+                <div className="flex items-center gap-4">
+                    <Button variant="outline" size="sm" className="flex items-center gap-2" asChild>
+                        <Link to="/users">
+                            <ArrowLeft className="h-4 w-4" />
+                            Back to Users
+                        </Link>
+                    </Button>
+                </div>
+                <div className="space-y-4">
+                    <img src={photo || placeholder} alt={user.name} className="h-32 w-32 object-cover rounded" />
+                    <h1 className="text-3xl font-bold">{user.name}</h1>
+                    <p className="text-gray-600">{user.email}</p>
+                    {user.profile && (
+                        <div className="space-y-2">
+                            {user.profile.alias && <p>Alias: {user.profile.alias}</p>}
+                            {user.profile.location && <p>Location: {user.profile.location}</p>}
+                            {user.profile.bio && <p>Bio: {user.profile.bio}</p>}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/UserFilters.tsx
+++ b/src/components/UserFilters.tsx
@@ -1,0 +1,30 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface UserFiltersProps {
+    filters: {
+        name: string;
+    };
+    onFilterChange: (filters: UserFiltersProps['filters']) => void;
+}
+
+export default function UserFilters({ filters, onFilterChange }: UserFiltersProps) {
+    return (
+        <div className="space-y-4">
+            <div className="grid gap-6 md:grid-cols-4 lg:grid-cols-4">
+                <div className="space-y-2">
+                    <Label htmlFor="name">User Name</Label>
+                    <div className="relative">
+                        <Input
+                            id="name"
+                            placeholder="Search users..."
+                            className="pl-3"
+                            value={filters.name}
+                            onChange={(e) => onFilterChange({ ...filters, name: e.target.value })}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/Users.tsx
+++ b/src/components/Users.tsx
@@ -1,0 +1,170 @@
+import { useState, useEffect } from 'react';
+import { useUsers } from '../hooks/useUsers';
+import UserFilters from './UserFilters';
+import UserCard from './UserCard';
+import { Pagination } from './Pagination';
+import { Loader2 } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import { Button } from '@/components/ui/button';
+import { X } from 'lucide-react';
+
+const sortOptions = [
+    { value: 'name', label: 'Name' },
+    { value: 'created_at', label: 'Recently Added' }
+];
+
+export default function Users() {
+    const [filtersVisible, setFiltersVisible] = useState<boolean>(() => {
+        const savedState = localStorage.getItem('filtersVisible');
+        return savedState ? JSON.parse(savedState) : true;
+    });
+
+    useEffect(() => {
+        localStorage.setItem('filtersVisible', JSON.stringify(filtersVisible));
+    }, [filtersVisible]);
+
+    const toggleFilters = () => {
+        setFiltersVisible(!filtersVisible);
+    };
+
+    const [filters, setFilters] = useState({
+        name: '',
+    });
+
+    const [page, setPage] = useState(1);
+    const [itemsPerPage, setItemsPerPage] = useLocalStorage('usersPerPage', 25);
+    const [sort, setSort] = useState('name');
+    const [direction, setDirection] = useState<'asc' | 'desc'>('asc');
+
+    const { data, isLoading, error } = useUsers({
+        filters,
+        page,
+        itemsPerPage,
+        sort,
+        direction,
+    });
+
+    const handlePageChange = (newPage: number) => {
+        setPage(newPage);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    const handleItemsPerPageChange = (count: number) => {
+        setItemsPerPage(count);
+        setPage(1);
+    };
+
+    const renderPagination = () => {
+        if (!data) return null;
+        return (
+            <Pagination
+                currentPage={page}
+                totalPages={data.last_page}
+                onPageChange={handlePageChange}
+                itemCount={data.data.length}
+                totalItems={data.total}
+                itemsPerPage={itemsPerPage}
+                onItemsPerPageChange={handleItemsPerPageChange}
+                sort={sort}
+                setSort={setSort}
+                direction={direction}
+                setDirection={setDirection}
+                sortOptions={sortOptions}
+            />
+        );
+    };
+
+    const hasActiveFilters = filters.name.trim() !== '';
+
+    const handleClearAllFilters = () => {
+        setFilters({ name: '' });
+    };
+
+    return (
+        <div className="bg-background text-foreground min-h-screen p-4">
+            <div className="mx-auto px-6 py-8 max-w-[2400px]">
+                <div className="space-y-8">
+                    <div className="flex flex-col space-y-2">
+                        <h1 className="text-4xl font-bold tracking-tight text-gray-900">Users</h1>
+                        <p className="text-lg text-gray-500">Browse all users</p>
+                    </div>
+
+                    <div className="relative">
+                        <div className="flex items-center gap-4">
+                            <div className="flex items-center gap-2">
+                                <button
+                                    onClick={toggleFilters}
+                                    className="mb-4 flex items-center border rounded-t-md px-4 py-2 shadow-sm"
+                                >
+                                    {filtersVisible ? (
+                                        <>
+                                            <FontAwesomeIcon icon={faChevronUp} className="mr-2" />
+                                            Hide Filters
+                                        </>
+                                    ) : (
+                                        <>
+                                            <FontAwesomeIcon icon={faChevronDown} className="mr-2" />
+                                            Show Filters
+                                        </>
+                                    )}
+                                </button>
+                                {hasActiveFilters && (
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={handleClearAllFilters}
+                                        className="mb-4 text-gray-500 hover:text-gray-900"
+                                    >
+                                        Clear All
+                                        <X className="ml-2 h-4 w-4" />
+                                    </Button>
+                                )}
+                            </div>
+                        </div>
+                        {filtersVisible && (
+                            <Card className="border-gray-100 shadow-sm">
+                                <CardContent className="p-6 space-y-4">
+                                    <UserFilters filters={filters} onFilterChange={setFilters} />
+                                </CardContent>
+                            </Card>
+                        )}
+                    </div>
+
+                    {error ? (
+                        <Alert variant="destructive">
+                            <AlertDescription>
+                                There was an error loading users. Please try again later.
+                            </AlertDescription>
+                        </Alert>
+                    ) : isLoading ? (
+                        <div className="flex h-96 items-center justify-center">
+                            <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+                        </div>
+                    ) : data?.data && data.data.length > 0 ? (
+                        <>
+                            {renderPagination()}
+
+                            <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                                {data.data.map((user) => (
+                                    <UserCard key={user.id} user={user} />
+                                ))}
+                            </div>
+
+                            {renderPagination()}
+                        </>
+                    ) : (
+                        <Card className="border-gray-100">
+                            <CardContent className="flex h-96 items-center justify-center text-gray-500">
+                                No users found. Try adjusting your filters.
+                            </CardContent>
+                        </Card>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import type { PaginatedResponse } from '../types/api';
+import type { User } from '../types/auth';
+
+export interface UserFilters {
+    name: string;
+}
+
+interface UseUsersParams {
+    page?: number;
+    itemsPerPage?: number;
+    filters?: UserFilters;
+    sort?: string;
+    direction?: 'desc' | 'asc';
+}
+
+export const useUsers = ({ page = 1, itemsPerPage = 25, filters, sort = 'name', direction = 'asc' }: UseUsersParams = {}) => {
+    return useQuery<PaginatedResponse<User>>({
+        queryKey: ['users', page, itemsPerPage, filters, sort, direction],
+        queryFn: async () => {
+            const params = new URLSearchParams();
+            params.append('page', page.toString());
+            params.append('limit', itemsPerPage.toString());
+            if (filters?.name) params.append('filters[name]', filters.name);
+            if (sort) params.append('sort', sort);
+            if (direction) params.append('direction', direction);
+
+            const { data } = await api.get<PaginatedResponse<User>>(`/users?${params.toString()}`);
+            return data;
+        },
+    });
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -8,6 +8,8 @@ import { EventDetailRoute } from './routes/event-detail.tsx';
 import { EntityDetailRoute } from './routes/entity-detail.tsx';
 import { SeriesDetailRoute } from './routes/series-detail.tsx';
 import { TagDetailRoute } from './routes/tag-detail.tsx';
+import { UsersRoute } from './routes/users.tsx';
+import { UserDetailRoute } from './routes/user-detail.tsx';
 import { EventCreateRoute } from './routes/event-create.tsx';
 import { EventEditRoute } from './routes/event-edit.tsx';
 import { SeriesCreateRoute } from './routes/series-create.tsx';
@@ -83,6 +85,7 @@ const routeTree = rootRoute.addChildren([
     entityRoute,
     seriesRoute,
     tagRoute,
+    UsersRoute,
     EventCreateRoute,
     EventEditRoute,
     SeriesCreateRoute,
@@ -93,6 +96,7 @@ const routeTree = rootRoute.addChildren([
     EntityDetailRoute,
     SeriesDetailRoute,
     TagDetailRoute,
+    UserDetailRoute,
     accountRoute,
     calendarRoute,
     RadarRoute,

--- a/src/routes/user-detail.tsx
+++ b/src/routes/user-detail.tsx
@@ -1,0 +1,12 @@
+import { createRoute } from '@tanstack/react-router';
+import { rootRoute } from './root';
+import UserDetail from '../components/UserDetail';
+
+export const UserDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/users/$id',
+    component: function UserDetailWrapper() {
+        const params = UserDetailRoute.useParams();
+        return <UserDetail id={params.id} />;
+    },
+});

--- a/src/routes/users.tsx
+++ b/src/routes/users.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import { rootRoute } from './root';
+import Users from '../components/Users';
+
+export const UsersRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/users',
+    component: Users,
+});


### PR DESCRIPTION
## Summary
- add a useUsers hook for fetching paginated users
- add Users page with filters and pagination
- create UserCard and UserDetail components
- wire up routes for `/users` and `/users/$id`
- link Users page in the sidebar menu

## Testing
- `npm run lint`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c06d442708322b8ae1c6653d4363d