### PR TITLE
Add simple search page

### DIFF
--- a/src/__tests__/components/MenuBar.test.tsx
+++ b/src/__tests__/components/MenuBar.test.tsx
@@ -6,7 +6,8 @@ import { authService } from '../../services/auth.service'
 
 // Mock Link component from react-router to avoid needing RouterProvider
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  useNavigate: () => vi.fn(),
 }))
 
 // Mock route components to avoid API calls if rendered

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { authService } from '../services/auth.service';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { Button } from './ui/button';
-import { HiCalendar, HiOfficeBuilding, HiUser, HiUserGroup, HiMoon, HiSun, HiMenu, HiCollection, HiTag, HiInformationCircle, HiQuestionMarkCircle } from 'react-icons/hi';
+import { HiCalendar, HiOfficeBuilding, HiUser, HiUserGroup, HiMoon, HiSun, HiMenu, HiCollection, HiTag, HiInformationCircle, HiQuestionMarkCircle, HiSearch } from 'react-icons/hi';
 import { Sheet, SheetContent, SheetTrigger } from './ui/sheet';
 
 const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
@@ -54,6 +54,10 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
         <Link to="/tags" className="flex items-center gap-2 hover:underline">
           <HiTag />
           <span className=" xl:inline">Tags</span>
+        </Link>
+        <Link to="/search" className="flex items-center gap-2 hover:underline">
+          <HiSearch />
+          <span className=" xl:inline">Search</span>
         </Link>
         <Link to="/users" className="flex items-center gap-2 hover:underline">
           <HiUserGroup />

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
-import { Link } from '@tanstack/react-router';
+import React, { useState } from 'react';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { authService } from '../services/auth.service';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { Button } from './ui/button';
+import { Input } from './ui/input';
 import { HiCalendar, HiOfficeBuilding, HiUser, HiUserGroup, HiMoon, HiSun, HiMenu, HiCollection, HiTag, HiInformationCircle, HiQuestionMarkCircle, HiSearch } from 'react-icons/hi';
 import { Sheet, SheetContent, SheetTrigger } from './ui/sheet';
 
 const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
   const [theme, setTheme] = useLocalStorage<'light' | 'dark'>('theme', 'light');
+  const [search, setSearch] = useState('');
+  const navigate = useNavigate();
   const { data: user } = useQuery({
     queryKey: ['currentUser'],
     queryFn: authService.getCurrentUser,
@@ -26,6 +29,20 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
         <h1 className=" xl:block text-2xl font-bold text-center hover:underline">Arcane City</h1>
         <p className=" xl:block text-xs text-gray-500 dark:text-gray-400 text-center">pittsburgh events guide</p>
       </Link>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          const q = search.trim();
+          if (q) {
+            navigate({ to: '/search', search: { q } });
+            setSearch('');
+          }
+        }}
+        className="w-full flex gap-2 mt-2"
+      >
+        <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search" className="h-8" />
+        <Button type="submit" size="sm" variant="outline">Go</Button>
+      </form>
       <div className="w-full border-b border-gray-200 dark:border-gray-700 my-4"></div>
 
       <nav className="flex flex-col gap-2 items-center">

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -38,10 +38,14 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
             setSearch('');
           }
         }}
-        className="w-full flex gap-2 mt-2"
+        className="w-full mt-2 px-2 hidden xl:block"
       >
-        <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search" className="h-8" />
-        <Button type="submit" size="sm" variant="outline">Go</Button>
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search"
+          className="h-8 w-full"
+        />
       </form>
       <div className="w-full border-b border-gray-200 dark:border-gray-700 my-4"></div>
 
@@ -129,24 +133,47 @@ const MenuContent: React.FC<{ className?: string }> = ({ className = '' }) => {
 };
 
 const MenuBar: React.FC = () => {
+  const [search, setSearch] = useState('');
+  const navigate = useNavigate();
+
   return (
     <>
       {/* Mobile Menu */}
-      <div className="xl:hidden fixed top-0 left-0 w-full p-4 flex items-center bg-background border-b">
-        <Sheet>
-          <SheetTrigger asChild>
-            <Button variant="ghost" size="icon">
-              <HiMenu className="h-6 w-6" />
-            </Button>
-          </SheetTrigger>
-          <SheetContent side="left" className="w-64 p-0">
-            <MenuContent />
-          </SheetContent>
-        </Sheet>
-        <Link to="/" className="ml-4">
-          <span className="font-bold hover:underline">Arcane City</span>
-          <p className="text-xs text-gray-500 dark:text-gray-400">pittsburgh events guide</p>
-        </Link>
+      <div className="xl:hidden fixed top-0 left-0 w-full p-4 flex items-center justify-between bg-background border-b">
+        <div className="flex items-center">
+          <Sheet>
+            <SheetTrigger asChild>
+              <Button variant="ghost" size="icon">
+                <HiMenu className="h-6 w-6" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-64 p-0">
+              <MenuContent />
+            </SheetContent>
+          </Sheet>
+          <Link to="/" className="ml-4">
+            <span className="font-bold hover:underline">Arcane City</span>
+            <p className="text-xs text-gray-500 dark:text-gray-400">pittsburgh events guide</p>
+          </Link>
+        </div>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            const q = search.trim();
+            if (q) {
+              navigate({ to: '/search', search: { q } });
+              setSearch('');
+            }
+          }}
+          className="px-2"
+        >
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search"
+            className="h-8 w-40"
+          />
+        </form>
       </div>
 
       {/* Desktop Menu */}

--- a/src/hooks/useEntities.ts
+++ b/src/hooks/useEntities.ts
@@ -9,11 +9,12 @@ interface DateRange {
 }
 
 interface EntityFilters {
-    name: string;
-    entity_type: string;
-    role: string;
-    tag: string;
-    status: string;
+    name?: string;
+    entity_type?: string;
+    role?: string;
+    tag?: string;
+    status?: string;
+    created_at?: DateRange;
     start_at?: DateRange;
 }
 
@@ -38,6 +39,8 @@ export const useEntities = ({ page = 1, itemsPerPage = 25, filters, sort = 'name
             if (filters?.role) params.append('filters[role]', filters.role);
             if (filters?.tag) params.append('filters[tag]', toKebabCase(filters.tag));
             if (filters?.status) params.append('filters[status]', filters.status);
+            if (filters?.created_at?.start) params.append('filters[created_at][start]', filters.created_at.start);
+            if (filters?.created_at?.end) params.append('filters[created_at][end]', filters.created_at.end);
             if (filters?.start_at?.start) params.append('filters[start_at][start]', filters.start_at.start);
             if (filters?.start_at?.end) params.append('filters[start_at][end]', filters.start_at.end);
             if (sort) params.append('sort', sort);

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -18,6 +18,8 @@ export const useEvents = ({ page = 1, itemsPerPage = 25, filters, sort = 'start_
             if (filters?.entity) params.append('filters[related]', filters.entity);
             if (filters?.event_type) params.append('filters[event_type]', toKebabCase(filters.event_type));
             if (filters?.series) params.append('filters[series]', filters.series);
+            if (filters?.created_at?.start) params.append('filters[created_at][start]', filters.created_at.start);
+            if (filters?.created_at?.end) params.append('filters[created_at][end]', filters.created_at.end);
             if (filters?.start_at?.start) params.append('filters[start_at][start]', filters.start_at.start);
             if (filters?.start_at?.end) params.append('filters[start_at][end]', filters.start_at.end);
             if (sort) params.append('sort', sort);

--- a/src/hooks/useSeries.ts
+++ b/src/hooks/useSeries.ts
@@ -9,10 +9,10 @@ interface DateRange {
 }
 
 interface SeriesFilters {
-    name: string;
-    event_type: string;
-    tag: string;
-    entity: string;
+    name?: string;
+    event_type?: string;
+    tag?: string;
+    entity?: string;
     created_at?: DateRange;
 }
 

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -4,6 +4,10 @@ import type { Tag, PaginatedResponse } from '../types/api';
 
 export interface TagFilters {
     name: string;
+    created_at?: {
+        start?: string;
+        end?: string;
+    };
 }
 
 interface UseTagsParams {
@@ -22,6 +26,8 @@ export const useTags = ({ page = 1, itemsPerPage = 25, filters, sort = 'name', d
             params.append('page', page.toString());
             params.append('limit', itemsPerPage.toString());
             if (filters?.name) params.append('filters[name]', filters.name);
+            if (filters?.created_at?.start) params.append('filters[created_at][start]', filters.created_at.start);
+            if (filters?.created_at?.end) params.append('filters[created_at][end]', filters.created_at.end);
             if (sort) params.append('sort', sort);
             if (direction) params.append('direction', direction);
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -28,6 +28,7 @@ import { PrivacyRoute } from './routes/privacy';
 import { HelpRoute } from './routes/help';
 import { RadarRoute } from './routes/radar';
 import { authService } from './services/auth.service';
+import { SearchRoute } from './routes/search';
 
 // Create routes
 const indexRoute = createRoute({
@@ -104,6 +105,7 @@ const routeTree = rootRoute.addChildren([
     RadarRoute,
     AboutRoute,
     HelpRoute,
+    SearchRoute,
     LoginRoute,
     PasswordRecoveryRoute,
     PrivacyRoute,

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+import { createRoute, Link } from '@tanstack/react-router';
+import { rootRoute } from './root';
+import { useEvents } from '../hooks/useEvents';
+import { useEntities } from '../hooks/useEntities';
+import { useSeries } from '../hooks/useSeries';
+import { useTags } from '../hooks/useTags';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+
+interface ParsedQuery {
+  name: string;
+  createdBefore?: string;
+  createdAfter?: string;
+}
+
+function parseSearchQuery(q: string): ParsedQuery {
+  const tokens = q.split(/\s+/).filter(Boolean);
+  const nameParts: string[] = [];
+  let createdBefore: string | undefined;
+  let createdAfter: string | undefined;
+
+  tokens.forEach((t) => {
+    const [key, val] = t.split(':');
+    if (/^CreatedBefore$/i.test(key) && val) {
+      createdBefore = val;
+    } else if (/^CreatedAfter$/i.test(key) && val) {
+      createdAfter = val;
+    } else {
+      nameParts.push(t);
+    }
+  });
+
+  return { name: nameParts.join(' '), createdBefore, createdAfter };
+}
+
+const Search: React.FC = () => {
+  const [input, setInput] = useState('');
+  const [query, setQuery] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setQuery(input.trim());
+  };
+
+  const { name, createdBefore, createdAfter } = parseSearchQuery(query);
+
+  const dateFilter = createdBefore || createdAfter ? { start: createdAfter, end: createdBefore } : undefined;
+
+  const { data: eventData } = useEvents({ itemsPerPage: 5, filters: { name, created_at: dateFilter } });
+  const { data: entityData } = useEntities({ itemsPerPage: 5, filters: { name, created_at: dateFilter } });
+  const { data: seriesData } = useSeries({ itemsPerPage: 5, filters: { name, created_at: dateFilter } });
+  const { data: tagData } = useTags({ itemsPerPage: 5, filters: { name, created_at: dateFilter } });
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-6">
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <Input value={input} onChange={(e) => setInput(e.target.value)} placeholder="Search" />
+        <button type="submit" className="px-4 py-2 border rounded">Search</button>
+      </form>
+
+      {query && (
+        <div className="space-y-6">
+          {eventData?.data?.length ? (
+            <Card>
+              <CardContent className="p-4 space-y-2">
+                <h2 className="text-xl font-semibold">Events</h2>
+                <ul className="list-disc ml-6 space-y-1">
+                  {eventData.data.map((ev) => (
+                    <li key={ev.id}>
+                      <Link to="/events/$slug" params={{ slug: ev.slug }} className="hover:underline">
+                        {ev.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {entityData?.data?.length ? (
+            <Card>
+              <CardContent className="p-4 space-y-2">
+                <h2 className="text-xl font-semibold">Entities</h2>
+                <ul className="list-disc ml-6 space-y-1">
+                  {entityData.data.map((en) => (
+                    <li key={en.id}>
+                      <Link to="/entities" search={{ name: en.name }} className="hover:underline">
+                        {en.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {seriesData?.data?.length ? (
+            <Card>
+              <CardContent className="p-4 space-y-2">
+                <h2 className="text-xl font-semibold">Series</h2>
+                <ul className="list-disc ml-6 space-y-1">
+                  {seriesData.data.map((se) => (
+                    <li key={se.id}>
+                      <Link to="/series/$slug" params={{ slug: se.slug }} className="hover:underline">
+                        {se.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {tagData?.data?.length ? (
+            <Card>
+              <CardContent className="p-4 space-y-2">
+                <h2 className="text-xl font-semibold">Tags</h2>
+                <ul className="list-disc ml-6 space-y-1">
+                  {tagData.data.map((tag) => (
+                    <li key={tag.id}>
+                      <Link to="/tags/$slug" params={{ slug: tag.slug }} className="hover:underline">
+                        {tag.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const SearchRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/search',
+  component: Search,
+});
+

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -1,12 +1,15 @@
-import React, { useState } from 'react';
-import { createRoute, Link } from '@tanstack/react-router';
+import React, { useState, useEffect } from 'react';
+import { createRoute, useNavigate, useSearch } from '@tanstack/react-router';
 import { rootRoute } from './root';
 import { useEvents } from '../hooks/useEvents';
 import { useEntities } from '../hooks/useEntities';
 import { useSeries } from '../hooks/useSeries';
 import { useTags } from '../hooks/useTags';
 import { Input } from '@/components/ui/input';
-import { Card, CardContent } from '@/components/ui/card';
+import EventCardCondensed from '../components/EventCardCondensed';
+import EntityCardCondensed from '../components/EntityCardCondensed';
+import SeriesCardCondensed from '../components/SeriesCardCondensed';
+import TagCard from '../components/TagCard';
 
 interface ParsedQuery {
   name: string;
@@ -34,16 +37,23 @@ function parseSearchQuery(q: string): ParsedQuery {
   return { name: nameParts.join(' '), createdBefore, createdAfter };
 }
 
+interface SearchParams { q?: string }
+
 const Search: React.FC = () => {
-  const [input, setInput] = useState('');
-  const [query, setQuery] = useState('');
+  const navigate = useNavigate();
+  const { q = '' } = useSearch({ from: '/search' }) as SearchParams;
+  const [input, setInput] = useState(q);
+
+  useEffect(() => {
+    setInput(q);
+  }, [q]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    setQuery(input.trim());
+    navigate({ to: '/search', search: { q: input.trim() } });
   };
 
-  const { name, createdBefore, createdAfter } = parseSearchQuery(query);
+  const { name, createdBefore, createdAfter } = parseSearchQuery(q);
 
   const dateFilter = createdBefore || createdAfter ? { start: createdAfter, end: createdBefore } : undefined;
 
@@ -52,84 +62,93 @@ const Search: React.FC = () => {
   const { data: seriesData } = useSeries({ itemsPerPage: 5, filters: { name, created_at: dateFilter } });
   const { data: tagData } = useTags({ itemsPerPage: 5, filters: { name, created_at: dateFilter } });
 
-  return (
-    <div className="max-w-3xl mx-auto p-4 space-y-6">
-      <form onSubmit={handleSubmit} className="flex gap-2">
-        <Input value={input} onChange={(e) => setInput(e.target.value)} placeholder="Search" />
-        <button type="submit" className="px-4 py-2 border rounded">Search</button>
-      </form>
+  const allEventImages = eventData?.data
+    .filter(ev => ev.primary_photo && ev.primary_photo_thumbnail)
+    .map(ev => ({ src: ev.primary_photo!, alt: ev.name, thumbnail: ev.primary_photo_thumbnail })) ?? [];
 
-      {query && (
-        <div className="space-y-6">
+  const allEntityImages = entityData?.data
+    .filter(en => en.primary_photo && en.primary_photo_thumbnail)
+    .map(en => ({ src: en.primary_photo!, alt: en.name, thumbnail: en.primary_photo_thumbnail })) ?? [];
+
+  const allSeriesImages = seriesData?.data
+    .filter(se => se.primary_photo && se.primary_photo_thumbnail)
+    .map(se => ({ src: se.primary_photo!, alt: se.name, thumbnail: se.primary_photo_thumbnail })) ?? [];
+
+  return (
+    <div className="bg-background text-foreground min-h-screen p-4">
+      <div className="mx-auto px-6 py-8 max-w-[2400px] space-y-8">
+        <div className="flex flex-col space-y-2">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900">Search</h1>
+          <p className="text-lg text-gray-500">Find events, entities, series and tags</p>
+        </div>
+        <form onSubmit={handleSubmit} className="flex gap-2 max-w-md">
+          <Input value={input} onChange={(e) => setInput(e.target.value)} placeholder="Search" />
+          <button type="submit" className="px-4 py-2 border rounded">Search</button>
+        </form>
+
+        {q && (
+          <div className="space-y-8">
           {eventData?.data?.length ? (
-            <Card>
-              <CardContent className="p-4 space-y-2">
-                <h2 className="text-xl font-semibold">Events</h2>
-                <ul className="list-disc ml-6 space-y-1">
-                  {eventData.data.map((ev) => (
-                    <li key={ev.id}>
-                      <Link to="/events/$slug" params={{ slug: ev.slug }} className="hover:underline">
-                        {ev.name}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
+            <section>
+              <h2 className="text-2xl font-semibold mb-4">Events</h2>
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
+                {eventData.data.map((ev) => (
+                  <EventCardCondensed
+                    key={ev.id}
+                    event={ev}
+                    allImages={allEventImages}
+                    imageIndex={allEventImages.findIndex(img => img.src === ev.primary_photo)}
+                  />
+                ))}
+              </div>
+            </section>
           ) : null}
 
           {entityData?.data?.length ? (
-            <Card>
-              <CardContent className="p-4 space-y-2">
-                <h2 className="text-xl font-semibold">Entities</h2>
-                <ul className="list-disc ml-6 space-y-1">
-                  {entityData.data.map((en) => (
-                    <li key={en.id}>
-                      <Link to="/entities" search={{ name: en.name }} className="hover:underline">
-                        {en.name}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
+            <section>
+              <h2 className="text-2xl font-semibold mb-4">Entities</h2>
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
+                {entityData.data.map((en) => (
+                  <EntityCardCondensed
+                    key={en.id}
+                    entity={en}
+                    allImages={allEntityImages}
+                    imageIndex={allEntityImages.findIndex(img => img.src === en.primary_photo)}
+                  />
+                ))}
+              </div>
+            </section>
           ) : null}
 
           {seriesData?.data?.length ? (
-            <Card>
-              <CardContent className="p-4 space-y-2">
-                <h2 className="text-xl font-semibold">Series</h2>
-                <ul className="list-disc ml-6 space-y-1">
-                  {seriesData.data.map((se) => (
-                    <li key={se.id}>
-                      <Link to="/series/$slug" params={{ slug: se.slug }} className="hover:underline">
-                        {se.name}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
+            <section>
+              <h2 className="text-2xl font-semibold mb-4">Series</h2>
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
+                {seriesData.data.map((se) => (
+                  <SeriesCardCondensed
+                    key={se.id}
+                    series={se}
+                    allImages={allSeriesImages}
+                    imageIndex={allSeriesImages.findIndex(img => img.src === se.primary_photo)}
+                  />
+                ))}
+              </div>
+            </section>
           ) : null}
 
           {tagData?.data?.length ? (
-            <Card>
-              <CardContent className="p-4 space-y-2">
-                <h2 className="text-xl font-semibold">Tags</h2>
-                <ul className="list-disc ml-6 space-y-1">
-                  {tagData.data.map((tag) => (
-                    <li key={tag.id}>
-                      <Link to="/tags/$slug" params={{ slug: tag.slug }} className="hover:underline">
-                        {tag.name}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
+            <section>
+              <h2 className="text-2xl font-semibold mb-4">Tags</h2>
+              <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                {tagData.data.map((tag) => (
+                  <TagCard key={tag.id} tag={tag} />
+                ))}
+              </div>
+            </section>
           ) : null}
         </div>
       )}
+      </div>
     </div>
   );
 };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -38,6 +38,10 @@ export interface UseEventsParams {
         entity?: string;
         tag?: string;
         series?: string;
+        created_at?: {
+            start?: string;
+            end?: string;
+        };
         start_at?: {
             start?: string;
             end?: string;


### PR DESCRIPTION
## Summary
- add a simple search page with query parsing for CreatedBefore/CreatedAfter
- support created_at filtering in hooks
- update API types and router
- link new page from the menu

## Testing
- `npm run lint`
- `npm test -- --run`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d1392d56083229681cdab614dee47