### PR TITLE
feat: enable tag creation and editing

### DIFF
--- a/src/components/TagDetail.tsx
+++ b/src/components/TagDetail.tsx
@@ -147,9 +147,18 @@ export default function TagDetail({ slug }: { slug: string }) {
                     <div className="flex items-start justify-between">
                         <h1 className="text-4xl font-bold text-gray-900">{tag.name}</h1>
                         {user && (
-                            <button onClick={handleFollowToggle} aria-label={following ? 'Unfollow' : 'Follow'}>
-                                <Star className={`h-6 w-6 ${following ? 'text-yellow-500' : 'text-gray-400'}`} fill={following ? 'currentColor' : 'none'} />
-                            </button>
+                            <div className="flex items-center gap-2">
+                                <button onClick={handleFollowToggle} aria-label={following ? 'Unfollow' : 'Follow'}>
+                                    <Star className={`h-6 w-6 ${following ? 'text-yellow-500' : 'text-gray-400'}`} fill={following ? 'currentColor' : 'none'} />
+                                </button>
+                                {tag.created_by && user.id === tag.created_by && (
+                                    <Button size="sm" variant="outline" asChild>
+                                        <Link to="/tags/$slug/edit" params={{ slug }}>
+                                            Edit Tag
+                                        </Link>
+                                    </Button>
+                                )}
+                            </div>
                         )}
                     </div>
 

--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -14,6 +14,9 @@ import { TagFilters as TagFiltersType } from '../types/filters';
 import TagCard from './TagCard';
 import { Button } from '@/components/ui/button';
 import { X } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+import { authService } from '@/services/auth.service';
+import { useQuery } from '@tanstack/react-query';
 
 const sortOptions = [
     { value: 'name', label: 'Name' },
@@ -42,6 +45,12 @@ export default function Tags() {
     const [itemsPerPage, setItemsPerPage] = useLocalStorage('tagsPerPage', 25);
     const [sort, setSort] = useState('name');
     const [direction, setDirection] = useState<'asc' | 'desc'>('asc');
+
+    const { data: user } = useQuery({
+        queryKey: ['currentUser'],
+        queryFn: authService.getCurrentUser,
+        enabled: authService.isAuthenticated(),
+    });
 
     const { data, isLoading, error } = useTags({
         filters,
@@ -95,6 +104,11 @@ export default function Tags() {
                         <div className="flex flex-col space-y-2">
                             <h1 className="text-4xl font-bold tracking-tight text-gray-900">Tags</h1>
                             <p className="text-lg text-gray-500">Browse all tags</p>
+                            {user && (
+                                <Button asChild className="self-start">
+                                    <Link to="/tag/create">Create Tag</Link>
+                                </Button>
+                            )}
                         </div>
 
                         <div className="relative">

--- a/src/hooks/useTagTypes.ts
+++ b/src/hooks/useTagTypes.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import type { TagType, PaginatedResponse } from '../types/api';
+
+export const useTagTypes = () => {
+  return useQuery<TagType[]>({
+    queryKey: ['tag-types'],
+    queryFn: async () => {
+      const { data } = await api.get<PaginatedResponse<TagType>>('/tag-types?limit=100&sort=name&direction=asc');
+      return data.data;
+    },
+  });
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -8,6 +8,8 @@ import { EventDetailRoute } from './routes/event-detail.tsx';
 import { EntityDetailRoute } from './routes/entity-detail.tsx';
 import { SeriesDetailRoute } from './routes/series-detail.tsx';
 import { TagDetailRoute } from './routes/tag-detail.tsx';
+import { TagCreateRoute } from './routes/tag-create.tsx';
+import { TagEditRoute } from './routes/tag-edit.tsx';
 import { UsersRoute } from './routes/users.tsx';
 import { UserDetailRoute } from './routes/user-detail.tsx';
 import { EventCreateRoute } from './routes/event-create.tsx';
@@ -88,6 +90,8 @@ const routeTree = rootRoute.addChildren([
     seriesRoute,
     tagRoute,
     UsersRoute,
+    TagCreateRoute,
+    TagEditRoute,
     EventCreateRoute,
     EventEditRoute,
     SeriesCreateRoute,

--- a/src/routes/tag-create.tsx
+++ b/src/routes/tag-create.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react';
+import { createRoute, useNavigate, Link } from '@tanstack/react-router';
+import { rootRoute } from './root';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { api } from '@/lib/api';
+import { AxiosError } from 'axios';
+import { formatApiError, toKebabCase } from '@/lib/utils';
+import { authService } from '../services/auth.service';
+import { useSearchOptions } from '../hooks/useSearchOptions';
+
+interface ValidationErrors {
+  [key: string]: string[];
+}
+
+const TagCreate: React.FC = () => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    name: '',
+    slug: '',
+    description: '',
+    tag_type_id: '' as number | '',
+  });
+  const [errors, setErrors] = useState<ValidationErrors>({});
+  const [generalError, setGeneralError] = useState('');
+
+  const { data: tagTypeOptions } = useSearchOptions('tag-types', '');
+
+  if (!authService.isAuthenticated()) {
+    return (
+      <div className="p-6">You must be logged in to create a tag.</div>
+    );
+  }
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData(prev => {
+      const updated = { ...prev, [name]: value } as typeof formData;
+      if (name === 'name') {
+        updated.slug = toKebabCase(value);
+      }
+      return updated;
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrors({});
+    setGeneralError('');
+    try {
+      const payload = {
+        ...formData,
+        tag_type_id: formData.tag_type_id || undefined,
+      };
+      const { data } = await api.post('/tags', payload);
+      navigate({ to: '/tags/$slug', params: { slug: data.slug } });
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.status === 422) {
+        setErrors(error.response.data.errors || {});
+      } else {
+        setGeneralError(formatApiError(error));
+      }
+    }
+  };
+
+  const renderError = (field: string) => {
+    if (errors[field]) {
+      return (
+        <p className="text-sm text-red-500 mt-1">{errors[field].join(', ')}</p>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-6 space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="outline" size="sm" asChild>
+          <Link to="/tags">Back</Link>
+        </Button>
+      </div>
+      <h1 className="text-3xl font-bold">Create Tag</h1>
+      {generalError && (
+        <div className="text-red-500">{generalError}</div>
+      )}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" name="name" value={formData.name} onChange={handleChange} />
+          {renderError('name')}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="slug">Slug</Label>
+          <Input id="slug" name="slug" value={formData.slug} onChange={handleChange} />
+          {renderError('slug')}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="description">Description</Label>
+          <Textarea id="description" name="description" value={formData.description} onChange={handleChange} />
+          {renderError('description')}
+        </div>
+        <div className="space-y-2">
+          <Label>Tag Type</Label>
+          <Select
+            value={formData.tag_type_id ? String(formData.tag_type_id) : ''}
+            onValueChange={v =>
+              setFormData(p => ({ ...p, tag_type_id: Number(v) }))
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select a tag type" />
+            </SelectTrigger>
+            <SelectContent>
+              {tagTypeOptions?.map(opt => (
+                <SelectItem key={opt.id} value={String(opt.id)}>
+                  {opt.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {renderError('tag_type_id')}
+        </div>
+        <Button type="submit" className="w-full">Create Tag</Button>
+      </form>
+    </div>
+  );
+};
+
+export const TagCreateRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/tag/create',
+  component: TagCreate,
+});
+

--- a/src/routes/tag-create.tsx
+++ b/src/routes/tag-create.tsx
@@ -10,7 +10,7 @@ import { api } from '@/lib/api';
 import { AxiosError } from 'axios';
 import { formatApiError, toKebabCase } from '@/lib/utils';
 import { authService } from '../services/auth.service';
-import { useSearchOptions } from '../hooks/useSearchOptions';
+import { useTagTypes } from '../hooks/useTagTypes';
 
 interface ValidationErrors {
   [key: string]: string[];
@@ -27,7 +27,7 @@ const TagCreate: React.FC = () => {
   const [errors, setErrors] = useState<ValidationErrors>({});
   const [generalError, setGeneralError] = useState('');
 
-  const { data: tagTypeOptions } = useSearchOptions('tag-types', '');
+  const { data: tagTypeOptions } = useTagTypes();
 
   if (!authService.isAuthenticated()) {
     return (

--- a/src/routes/tag-create.tsx
+++ b/src/routes/tag-create.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { createRoute, useNavigate, Link } from '@tanstack/react-router';
 import { rootRoute } from './root';
 import { Input } from '@/components/ui/input';
@@ -22,12 +22,22 @@ const TagCreate: React.FC = () => {
     name: '',
     slug: '',
     description: '',
-    tag_type_id: '' as number | '',
+    tag_type_id: 1 as number | '',
   });
   const [errors, setErrors] = useState<ValidationErrors>({});
   const [generalError, setGeneralError] = useState('');
 
   const { data: tagTypeOptions } = useTagTypes();
+
+  // Set default tag type to "Category" when options are loaded
+  useEffect(() => {
+    if (tagTypeOptions && tagTypeOptions.length > 0) {
+      const categoryOption = tagTypeOptions.find(option => option.name.toLowerCase() === 'category');
+      if (categoryOption && formData.tag_type_id === 1) {
+        setFormData(prev => ({ ...prev, tag_type_id: categoryOption.id }));
+      }
+    }
+  }, [tagTypeOptions, formData.tag_type_id]);
 
   if (!authService.isAuthenticated()) {
     return (

--- a/src/routes/tag-edit.tsx
+++ b/src/routes/tag-edit.tsx
@@ -1,0 +1,178 @@
+import React, { useState, useEffect } from 'react';
+import { createRoute, useNavigate, Link } from '@tanstack/react-router';
+import { rootRoute } from './root';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { api } from '@/lib/api';
+import { AxiosError } from 'axios';
+import { formatApiError, toKebabCase } from '@/lib/utils';
+import { useQuery } from '@tanstack/react-query';
+import { authService } from '../services/auth.service';
+import { useSearchOptions } from '../hooks/useSearchOptions';
+import { Tag } from '../types/api';
+
+interface ValidationErrors {
+  [key: string]: string[];
+}
+
+const TagEdit: React.FC<{ slug: string }> = ({ slug }) => {
+  const navigate = useNavigate();
+
+  const { data: tag, isLoading: tagLoading } = useQuery<Tag>({
+    queryKey: ['tag', slug],
+    queryFn: async () => {
+      const { data } = await api.get<Tag>(`/tags/${slug}`);
+      return data;
+    },
+  });
+
+  const { data: user } = useQuery({
+    queryKey: ['currentUser'],
+    queryFn: authService.getCurrentUser,
+    enabled: authService.isAuthenticated(),
+  });
+
+  const { data: tagTypeOptions } = useSearchOptions('tag-types', '');
+
+  const [formData, setFormData] = useState({
+    name: '',
+    slug: '',
+    description: '',
+    tag_type_id: '' as number | '',
+  });
+  const [errors, setErrors] = useState<ValidationErrors>({});
+  const [generalError, setGeneralError] = useState('');
+
+  useEffect(() => {
+    if (tag) {
+      setFormData({
+        name: tag.name,
+        slug: tag.slug,
+        description: tag.description || '',
+        tag_type_id: (tag.tag_type_id || tag.tag_type?.id || '') as number | '',
+      });
+    }
+  }, [tag]);
+
+  if (!authService.isAuthenticated() || !user) {
+    return <div className="p-6">You must be logged in to edit a tag.</div>;
+  }
+
+  if (tag && user.id !== tag.created_by) {
+    return <div className="p-6">You are not authorized to edit this tag.</div>;
+  }
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData(prev => {
+      const updated = { ...prev, [name]: value } as typeof formData;
+      if (name === 'name') {
+        updated.slug = toKebabCase(value);
+      }
+      return updated;
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrors({});
+    setGeneralError('');
+    try {
+      const payload = {
+        ...formData,
+        tag_type_id: formData.tag_type_id || undefined,
+      };
+      await api.put(`/tags/${slug}`, payload);
+      navigate({ to: '/tags/$slug', params: { slug: formData.slug } });
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.status === 422) {
+        setErrors(error.response.data.errors || {});
+      } else {
+        setGeneralError(formatApiError(error));
+      }
+    }
+  };
+
+  const renderError = (field: string) => {
+    if (errors[field]) {
+      return (
+        <p className="text-sm text-red-500 mt-1">{errors[field].join(', ')}</p>
+      );
+    }
+    return null;
+  };
+
+  if (tagLoading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-6 space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="outline" size="sm" asChild>
+          <Link to="/tags/$slug" params={{ slug }}>
+            Back
+          </Link>
+        </Button>
+      </div>
+      <h1 className="text-3xl font-bold">Edit Tag</h1>
+      {generalError && (
+        <div className="text-red-500">{generalError}</div>
+      )}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" name="name" value={formData.name} onChange={handleChange} />
+          {renderError('name')}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="slug">Slug</Label>
+          <Input id="slug" name="slug" value={formData.slug} onChange={handleChange} />
+          {renderError('slug')}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="description">Description</Label>
+          <Textarea id="description" name="description" value={formData.description} onChange={handleChange} />
+          {renderError('description')}
+        </div>
+        <div className="space-y-2">
+          <Label>Tag Type</Label>
+          <Select
+            value={formData.tag_type_id ? String(formData.tag_type_id) : ''}
+            onValueChange={v =>
+              setFormData(p => ({ ...p, tag_type_id: Number(v) }))
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select a tag type" />
+            </SelectTrigger>
+            <SelectContent>
+              {tagTypeOptions?.map(opt => (
+                <SelectItem key={opt.id} value={String(opt.id)}>
+                  {opt.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {renderError('tag_type_id')}
+        </div>
+        <Button type="submit" className="w-full">Update Tag</Button>
+      </form>
+    </div>
+  );
+};
+
+export const TagEditRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/tags/$slug/edit',
+  component: function TagEditWrapper() {
+    const params = TagEditRoute.useParams();
+    return <TagEdit slug={params.slug} />;
+  },
+});
+

--- a/src/routes/tag-edit.tsx
+++ b/src/routes/tag-edit.tsx
@@ -11,7 +11,7 @@ import { AxiosError } from 'axios';
 import { formatApiError, toKebabCase } from '@/lib/utils';
 import { useQuery } from '@tanstack/react-query';
 import { authService } from '../services/auth.service';
-import { useSearchOptions } from '../hooks/useSearchOptions';
+import { useTagTypes } from '../hooks/useTagTypes';
 import { Tag } from '../types/api';
 
 interface ValidationErrors {
@@ -35,7 +35,7 @@ const TagEdit: React.FC<{ slug: string }> = ({ slug }) => {
     enabled: authService.isAuthenticated(),
   });
 
-  const { data: tagTypeOptions } = useSearchOptions('tag-types', '');
+    const { data: tagTypeOptions } = useTagTypes();
 
   const [formData, setFormData] = useState({
     name: '',

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -140,6 +140,13 @@ export interface Tag {
     name: string;
     slug: string;
     description?: string;
+    tag_type_id?: number;
+    tag_type?: {
+        id: number;
+        name: string;
+        slug: string;
+    };
+    created_by?: number;
 }
 
 export interface EntityType {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -135,17 +135,21 @@ export interface Role {
     slug: string;
 }
 
+export interface TagType {
+    id: number;
+    name: string;
+    slug?: string;
+    created_at?: string;
+    updated_at?: string;
+}
+
 export interface Tag {
     id: number;
     name: string;
     slug: string;
     description?: string;
     tag_type_id?: number;
-    tag_type?: {
-        id: number;
-        name: string;
-        slug: string;
-    };
+    tag_type?: TagType;
     created_by?: number;
 }
 


### PR DESCRIPTION
## Summary
- allow logged in users to create new tags
- allow tag creators to edit their tags
- expose routes and UI controls for tag creation and editing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b942fe20883228573bc44de4e6b17