### PR TITLE
feat: improve tag detail page

### DIFF
--- a/src/__tests__/components/TagDetail.test.tsx
+++ b/src/__tests__/components/TagDetail.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from '../test-render';
+import TagDetail from '../../components/TagDetail';
+import { vi, describe, it, beforeEach, expect } from 'vitest';
+import React from 'react';
+import { authService } from '../../services/auth.service';
+
+vi.mock('@tanstack/react-router', () => ({
+    Link: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) => (
+        <a {...props}>{children}</a>
+    ),
+    useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../../services/auth.service');
+
+vi.mock('../../lib/api', () => ({
+    api: {
+        get: vi.fn((url: string) => {
+            const paginated = { data: [], current_page: 1, last_page: 1, per_page: 5, total: 0 };
+            if (url === '/tags/test-tag') {
+                return Promise.resolve({
+                    data: {
+                        id: 1,
+                        name: 'Test Tag',
+                        slug: 'test-tag',
+                        description: 'A test tag',
+                        tag_type: { id: 1, name: 'Genre' },
+                        created_by: 1,
+                    },
+                });
+            }
+            return Promise.resolve({ data: paginated });
+        }),
+        post: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+describe('TagDetail', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(authService.isAuthenticated).mockReturnValue(true);
+        vi.mocked(authService.getCurrentUser).mockResolvedValue({
+            id: 1,
+            name: 'testuser',
+            email: 'test@example.com',
+            status: { id: 1, name: 'active' },
+            email_verified_at: null,
+            last_active: null,
+            created_at: '2023-01-01T00:00:00Z',
+            updated_at: '2023-01-01T00:00:00Z',
+            followed_tags: [],
+            followed_entities: [],
+            followed_series: [],
+            followed_threads: [],
+            photos: [],
+        });
+    });
+
+    it('renders tag type and description', async () => {
+        render(<TagDetail slug="test-tag" />);
+
+        expect(await screen.findByText('Test Tag')).toBeInTheDocument();
+        expect(screen.getByText('Genre')).toBeInTheDocument();
+        expect(screen.getByText('A test tag')).toBeInTheDocument();
+    });
+
+    it('shows edit and delete options in actions menu', async () => {
+        render(<TagDetail slug="test-tag" />);
+
+        await screen.findByText('Test Tag');
+        const actionsButton = screen.getByLabelText('More actions');
+        fireEvent.click(actionsButton);
+        expect(screen.getByText('Edit Tag')).toBeInTheDocument();
+        expect(screen.getByText('Delete Tag')).toBeInTheDocument();
+    });
+});
+


### PR DESCRIPTION
## Summary
- show tag type and description on tag detail page
- add hamburger menu with edit/delete actions and confirm dialog
- cover tag detail page with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d061dcd1c83228360356a2cbc4fe5