### PR TITLE
Add Fantasy Flip playable mini-game with boards, route, and menu entry

### DIFF
--- a/public/images/fantasy-flip/city-board.svg
+++ b/public/images/fantasy-flip/city-board.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f6ead8"/>
+      <stop offset="100%" stop-color="#d6b89d"/>
+    </linearGradient>
+    <style>
+      .title{font:700 54px Georgia,serif;fill:#56331d}
+      .small{font:600 20px Arial,sans-serif;fill:#56331d}
+      .district{fill:#fff8ee;stroke:#704426;stroke-width:4}
+    </style>
+  </defs>
+  <rect width="1200" height="700" fill="url(#bg)"/>
+  <rect x="20" y="20" width="1160" height="660" rx="18" fill="none" stroke="#704426" stroke-width="8"/>
+  <text x="60" y="90" class="title">CITY • MINI-GAME DISTRICTS</text>
+  <text x="60" y="130" class="small">Visit establishments to convert actions into efficient combos.</text>
+
+  <rect class="district" x="80" y="180" width="230" height="140" rx="12"/>
+  <rect class="district" x="350" y="180" width="230" height="140" rx="12"/>
+  <rect class="district" x="620" y="180" width="230" height="140" rx="12"/>
+  <rect class="district" x="890" y="180" width="230" height="140" rx="12"/>
+
+  <rect class="district" x="80" y="360" width="230" height="140" rx="12"/>
+  <rect class="district" x="350" y="360" width="230" height="140" rx="12"/>
+  <rect class="district" x="620" y="360" width="230" height="140" rx="12"/>
+  <rect class="district" x="890" y="360" width="230" height="140" rx="12"/>
+
+  <text x="155" y="255" class="small">Market</text>
+  <text x="440" y="255" class="small">Forge</text>
+  <text x="692" y="255" class="small">Temple</text>
+  <text x="970" y="255" class="small">Library</text>
+  <text x="160" y="435" class="small">Tavern</text>
+  <text x="430" y="435" class="small">Arena</text>
+  <text x="675" y="435" class="small">Guild Hall</text>
+  <text x="930" y="435" class="small">Black Market</text>
+
+  <rect x="70" y="560" width="1040" height="90" rx="12" fill="#edd8c0" stroke="#704426" stroke-width="4"/>
+  <text x="95" y="615" class="small">Combo Route Bonus  |  Repeat Visit Tax  |  Civic Event Tracker □□□□</text>
+</svg>

--- a/public/images/fantasy-flip/dungeon-board.svg
+++ b/public/images/fantasy-flip/dungeon-board.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f8e8c7"/>
+      <stop offset="100%" stop-color="#e5c186"/>
+    </linearGradient>
+    <style>
+      .title{font:700 54px Georgia,serif;fill:#5e2f12}
+      .small{font:600 20px Arial,sans-serif;fill:#5e2f12}
+      .node{fill:#fff7df;stroke:#7e4b1f;stroke-width:4}
+      .path{stroke:#7e4b1f;stroke-width:6;fill:none}
+    </style>
+  </defs>
+  <rect x="0" y="0" width="1200" height="700" fill="url(#bg)"/>
+  <rect x="20" y="20" width="1160" height="660" rx="18" fill="none" stroke="#7e4b1f" stroke-width="8"/>
+  <text x="60" y="90" class="title">DUNGEON • MAZE CRAWL</text>
+  <text x="60" y="130" class="small">Navigate by suit/value, clear monsters, earn relics.</text>
+
+  <path class="path" d="M120 220 L280 220 L280 330 L430 330 L430 470 L640 470"/>
+  <path class="path" d="M280 220 L280 120 L520 120 L520 230 L700 230"/>
+  <path class="path" d="M430 330 L600 330 L600 210 L870 210"/>
+  <path class="path" d="M640 470 L860 470 L860 360 L1030 360"/>
+
+  <rect class="node" x="80" y="180" width="90" height="80" rx="10"/><text x="100" y="228" class="small">Start</text>
+  <rect class="node" x="240" y="180" width="90" height="80" rx="10"/><text x="252" y="228" class="small">♣ 2+</text>
+  <rect class="node" x="240" y="80" width="90" height="80" rx="10"/><text x="252" y="128" class="small">♥ 6+</text>
+  <rect class="node" x="390" y="290" width="90" height="80" rx="10"/><text x="404" y="338" class="small">♠ 4+</text>
+  <rect class="node" x="390" y="430" width="90" height="80" rx="10"/><text x="404" y="478" class="small">Trap</text>
+  <rect class="node" x="480" y="80" width="90" height="80" rx="10"/><text x="492" y="128" class="small">♦ 8+</text>
+  <rect class="node" x="560" y="290" width="90" height="80" rx="10"/><text x="570" y="338" class="small">Chest</text>
+  <rect class="node" x="660" y="190" width="90" height="80" rx="10"/><text x="674" y="238" class="small">Elite</text>
+  <rect class="node" x="830" y="170" width="90" height="80" rx="10"/><text x="845" y="218" class="small">Relic</text>
+  <rect class="node" x="820" y="430" width="90" height="80" rx="10"/><text x="838" y="478" class="small">Boss</text>
+  <rect class="node" x="990" y="320" width="120" height="90" rx="10"/><text x="1018" y="372" class="small">Gate</text>
+
+  <rect x="70" y="560" width="1040" height="90" rx="12" fill="#f2d7a6" stroke="#7e4b1f" stroke-width="4"/>
+  <text x="95" y="615" class="small">Threat Ladder: □ □ □ □ □  |  Lock Grid 3×3  |  Relic Draft Order</text>
+</svg>

--- a/public/images/fantasy-flip/forest-board.svg
+++ b/public/images/fantasy-flip/forest-board.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#dff5d2"/>
+      <stop offset="100%" stop-color="#9fd68a"/>
+    </linearGradient>
+    <style>
+      .title{font:700 54px Georgia,serif;fill:#1f4f25}
+      .small{font:600 20px Arial,sans-serif;fill:#1f4f25}
+      .zone{fill:#f4ffef;stroke:#2f6e34;stroke-width:4}
+      .path{stroke:#2f6e34;stroke-width:5;fill:none;stroke-dasharray:10 8}
+    </style>
+  </defs>
+  <rect width="1200" height="700" fill="url(#bg)"/>
+  <rect x="20" y="20" width="1160" height="660" rx="18" fill="none" stroke="#2f6e34" stroke-width="8"/>
+  <text x="60" y="90" class="title">FOREST • GATHERING GROUNDS</text>
+  <text x="60" y="130" class="small">Harvest, heal, brew, and watch for danger pulses.</text>
+
+  <ellipse class="zone" cx="220" cy="280" rx="150" ry="90"/>
+  <ellipse class="zone" cx="500" cy="230" rx="170" ry="100"/>
+  <ellipse class="zone" cx="800" cy="280" rx="180" ry="95"/>
+  <ellipse class="zone" cx="330" cy="470" rx="170" ry="100"/>
+  <ellipse class="zone" cx="700" cy="480" rx="210" ry="110"/>
+
+  <path class="path" d="M220 280 C300 190, 420 170, 500 230"/>
+  <path class="path" d="M500 230 C640 210, 720 230, 800 280"/>
+  <path class="path" d="M220 280 C250 370, 280 430, 330 470"/>
+  <path class="path" d="M330 470 C470 520, 570 500, 700 480"/>
+  <path class="path" d="M700 480 C760 420, 790 360, 800 280"/>
+
+  <text x="160" y="286" class="small">Grove</text>
+  <text x="445" y="236" class="small">River</text>
+  <text x="740" y="286" class="small">Ruins</text>
+  <text x="255" y="476" class="small">Deepwood</text>
+  <text x="620" y="486" class="small">Moon-Clearing</text>
+
+  <rect x="70" y="560" width="1040" height="90" rx="12" fill="#ccecbc" stroke="#2f6e34" stroke-width="4"/>
+  <text x="95" y="615" class="small">Recipes: Herb Sets □□□  |  Trail Chain Bonus  |  Danger Pulse: 1 in 6</text>
+</svg>

--- a/public/images/fantasy-flip/tower-board.svg
+++ b/public/images/fantasy-flip/tower-board.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ece2ff"/>
+      <stop offset="100%" stop-color="#bca4ff"/>
+    </linearGradient>
+    <style>
+      .title{font:700 54px Georgia,serif;fill:#2e175c}
+      .small{font:600 20px Arial,sans-serif;fill:#2e175c}
+      .floor{fill:#f9f4ff;stroke:#4a2b89;stroke-width:4}
+    </style>
+  </defs>
+  <rect width="1200" height="700" fill="url(#bg)"/>
+  <rect x="20" y="20" width="1160" height="660" rx="18" fill="none" stroke="#4a2b89" stroke-width="8"/>
+  <text x="60" y="90" class="title">TOWER • ARCANE ASCENT</text>
+  <text x="60" y="130" class="small">Choose Safe Ritual or Risk Surge as you climb.</text>
+
+  <g transform="translate(220,150)">
+    <rect class="floor" x="0" y="420" width="760" height="65" rx="10"/>
+    <rect class="floor" x="40" y="355" width="680" height="55" rx="10"/>
+    <rect class="floor" x="80" y="295" width="600" height="50" rx="10"/>
+    <rect class="floor" x="120" y="240" width="520" height="45" rx="10"/>
+    <rect class="floor" x="160" y="190" width="440" height="40" rx="10"/>
+    <rect class="floor" x="200" y="145" width="360" height="35" rx="10"/>
+    <rect class="floor" x="240" y="105" width="280" height="30" rx="10"/>
+    <rect class="floor" x="280" y="60" width="200" height="35" rx="10"/>
+    <text x="345" y="84" class="small">Apex Duel</text>
+    <text x="20" y="460" class="small">Floor 1</text><text x="620" y="460" class="small">Safe / Risk</text>
+  </g>
+
+  <rect x="70" y="560" width="1040" height="90" rx="12" fill="#dccfff" stroke="#4a2b89" stroke-width="4"/>
+  <text x="95" y="615" class="small">Rune Sequence: ♥ → ♣ → ♦ → ♠  |  Instability Wheel: ○ ○ ○ ○ ○</text>
+</svg>

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -6,7 +6,7 @@ import { useLocalStorage } from '../hooks/useLocalStorage';
 import { useMediaPlayerContext } from '../hooks/useMediaPlayerContext';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
-import { HiCalendar, HiOfficeBuilding, HiUser, HiUserGroup, HiMoon, HiSun, HiMenu, HiCollection, HiTag, HiBookOpen, HiInformationCircle, HiQuestionMarkCircle, HiSearch, HiVolumeUp, HiVolumeOff, HiWifi, HiChevronDown, HiChevronUp } from 'react-icons/hi';
+import { HiCalendar, HiOfficeBuilding, HiUser, HiUserGroup, HiMoon, HiSun, HiMenu, HiCollection, HiTag, HiBookOpen, HiInformationCircle, HiQuestionMarkCircle, HiSearch, HiVolumeUp, HiVolumeOff, HiWifi, HiChevronDown, HiChevronUp, HiSparkles } from 'react-icons/hi';
 import { Sheet, SheetContent, SheetTrigger } from './ui/sheet';
 
 const MenuContent: React.FC<{ className?: string; onNavigate?: () => void }> = ({ className = '', onNavigate }) => {
@@ -151,6 +151,10 @@ const MenuContent: React.FC<{ className?: string; onNavigate?: () => void }> = (
         <Link to="/search" className="flex items-center gap-2 hover:underline">
           <HiSearch />
           <span className=" xl:inline">Search</span>
+        </Link>
+        <Link to="/fantasy-flip" className="flex items-center gap-2 hover:underline">
+          <HiSparkles />
+          <span className=" xl:inline">Fantasy Flip</span>
         </Link>
 
         <div className="w-full border-b border-gray-200 dark:border-gray-700 my-4"></div>

--- a/src/components/fantasy-flip/FantasyFlipGame.tsx
+++ b/src/components/fantasy-flip/FantasyFlipGame.tsx
@@ -1,0 +1,557 @@
+import { useMemo, useState } from 'react';
+
+type Suit = 'spades' | 'hearts' | 'diamonds' | 'clubs';
+type ActionType = 'train' | 'act' | 'convert';
+type BoardType = 'dungeon' | 'tower' | 'forest' | 'city';
+
+interface Card {
+  suit: Suit;
+  rank: string;
+  value: number;
+}
+
+interface Player {
+  id: number;
+  name: string;
+  isBot: boolean;
+  hp: number;
+  focus: number;
+  xp: number;
+  gold: number;
+  relics: number;
+  materials: number;
+  herbs: number;
+  might: number;
+  spirit: number;
+  craft: number;
+  lore: number;
+  locationProgress: Record<BoardType, number>;
+  actionChoice: ActionType;
+  boardChoice: BoardType;
+}
+
+interface TurnLog {
+  round: number;
+  playerName: string;
+  text: string;
+}
+
+const SUIT_SYMBOL: Record<Suit, string> = {
+  spades: '♠',
+  hearts: '♥',
+  diamonds: '♦',
+  clubs: '♣',
+};
+
+const BOARD_LABELS: Record<BoardType, string> = {
+  dungeon: 'Dungeon',
+  tower: 'Tower',
+  forest: 'Forest',
+  city: 'City',
+};
+
+const BOARD_IMAGES: Record<BoardType, string> = {
+  dungeon: '/images/fantasy-flip/dungeon-board.svg',
+  tower: '/images/fantasy-flip/tower-board.svg',
+  forest: '/images/fantasy-flip/forest-board.svg',
+  city: '/images/fantasy-flip/city-board.svg',
+};
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const suitToAttribute = (suit: Suit): keyof Pick<Player, 'might' | 'spirit' | 'craft' | 'lore'> => {
+  if (suit === 'spades') return 'might';
+  if (suit === 'hearts') return 'spirit';
+  if (suit === 'diamonds') return 'craft';
+  return 'lore';
+};
+
+const makeDeck = (): Card[] => {
+  const suits: Suit[] = ['spades', 'hearts', 'diamonds', 'clubs'];
+  const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+  const deck: Card[] = [];
+  for (const suit of suits) {
+    for (const rank of ranks) {
+      let value = Number(rank);
+      if (rank === 'A') value = 1;
+      if (rank === 'J') value = 11;
+      if (rank === 'Q') value = 12;
+      if (rank === 'K') value = 13;
+      deck.push({ suit, rank, value });
+    }
+  }
+
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+
+  return deck;
+};
+
+const botActionChoice = (player: Player): { actionChoice: ActionType; boardChoice: BoardType } => {
+  const hpLow = player.hp <= 5;
+  const growthLow = Math.min(player.might, player.spirit, player.craft, player.lore) <= 3;
+
+  if (hpLow) {
+    return { actionChoice: 'convert', boardChoice: 'forest' };
+  }
+
+  if (growthLow) {
+    return { actionChoice: 'train', boardChoice: 'city' };
+  }
+
+  const boardByNeed: BoardType = player.relics < 2 ? 'dungeon' : player.focus < 4 ? 'tower' : player.gold < 8 ? 'city' : 'forest';
+
+  return { actionChoice: 'act', boardChoice: boardByNeed };
+};
+
+const makePlayer = (id: number, isBot: boolean): Player => ({
+  id,
+  name: isBot ? `Bot ${id}` : `Player ${id}`,
+  isBot,
+  hp: 12,
+  focus: 2,
+  xp: 0,
+  gold: 0,
+  relics: 0,
+  materials: 0,
+  herbs: 0,
+  might: 1,
+  spirit: 1,
+  craft: 1,
+  lore: 1,
+  locationProgress: {
+    dungeon: 0,
+    tower: 0,
+    forest: 0,
+    city: 0,
+  },
+  actionChoice: 'train',
+  boardChoice: 'dungeon',
+});
+
+const scorePlayer = (player: Player): number => {
+  const attrScore = player.might + player.spirit + player.craft + player.lore;
+  const locationScore = Object.values(player.locationProgress).reduce((sum, value) => sum + value, 0);
+  return player.xp + player.gold + (player.relics * 3) + player.materials + player.herbs + attrScore + locationScore + player.hp;
+};
+
+const resolveAction = (player: Player, actionChoice: ActionType, boardChoice: BoardType, playerCard: Card, adventureCard: Card): { updated: Player; logs: string[] } => {
+  const updated: Player = {
+    ...player,
+    locationProgress: { ...player.locationProgress },
+  };
+
+  const logs: string[] = [];
+  const cardValue = playerCard.value;
+  const cardSuit = playerCard.suit;
+  const checkTarget = Math.ceil(adventureCard.value / 2) + 2;
+
+  if (actionChoice === 'train') {
+    const trainedAttribute = suitToAttribute(cardSuit);
+    const gain = cardValue >= 11 ? 2 : 1;
+    updated[trainedAttribute] = clamp(updated[trainedAttribute] + gain, 0, 12);
+    updated.xp += gain;
+    logs.push(`${updated.name} trained ${trainedAttribute} +${gain}.`);
+  }
+
+  if (actionChoice === 'convert') {
+    updated.focus = clamp(updated.focus + 2, 0, 12);
+    updated.gold += 1;
+    if (cardSuit === 'hearts') {
+      updated.hp = clamp(updated.hp + 1, 0, 16);
+      logs.push(`${updated.name} converted and healed 1 HP.`);
+    } else {
+      logs.push(`${updated.name} converted card power to +2 focus and +1 gold.`);
+    }
+  }
+
+  if (actionChoice === 'act') {
+    const effectiveValue = cardValue + (updated.focus >= 1 ? 1 : 0);
+    updated.focus = clamp(updated.focus - 1, 0, 12);
+    updated.locationProgress[boardChoice] += 1;
+
+    if (boardChoice === 'dungeon') {
+      const combat = updated.might + (cardSuit === 'spades' ? 2 : 0) + Math.floor(effectiveValue / 4);
+      if (combat >= checkTarget) {
+        updated.relics += 1;
+        updated.xp += 2;
+        logs.push(`${updated.name} cleared a dungeon chamber and found a relic.`);
+      } else {
+        updated.hp = clamp(updated.hp - 1, 0, 16);
+        updated.xp += 1;
+        logs.push(`${updated.name} fought in the dungeon but took 1 damage.`);
+      }
+    }
+
+    if (boardChoice === 'tower') {
+      const arcana = updated.lore + updated.spirit + (cardSuit === 'clubs' ? 2 : 0);
+      updated.xp += 1;
+      if (arcana + Math.floor(effectiveValue / 5) >= checkTarget) {
+        updated.focus = clamp(updated.focus + 2, 0, 12);
+        updated.relics += 1;
+        logs.push(`${updated.name} stabilized tower runes and gained +2 focus and a relic.`);
+      } else {
+        updated.hp = clamp(updated.hp - 1, 0, 16);
+        logs.push(`${updated.name} triggered a tower backlash and lost 1 HP.`);
+      }
+    }
+
+    if (boardChoice === 'forest') {
+      const gather = updated.craft + updated.lore + (cardSuit === 'diamonds' ? 2 : 0);
+      if (gather >= checkTarget) {
+        updated.materials += 2;
+        updated.herbs += 1;
+        updated.hp = clamp(updated.hp + 1, 0, 16);
+        logs.push(`${updated.name} gathered resources in the forest (+2 materials, +1 herb, +1 HP).`);
+      } else {
+        updated.materials += 1;
+        if (adventureCard.suit === 'spades') {
+          updated.hp = clamp(updated.hp - 1, 0, 16);
+          logs.push(`${updated.name} found scraps in the forest but suffered an ambush (-1 HP).`);
+        } else {
+          logs.push(`${updated.name} foraged the forest (+1 material).`);
+        }
+      }
+    }
+
+    if (boardChoice === 'city') {
+      const civic = updated.spirit + updated.craft + (cardSuit === 'hearts' || cardSuit === 'diamonds' ? 1 : 0);
+      updated.gold += 1;
+      if (civic + Math.floor(effectiveValue / 5) >= checkTarget) {
+        updated.gold += 2;
+        updated.xp += 2;
+        logs.push(`${updated.name} chained city mini-games (+3 gold total, +2 XP).`);
+      } else {
+        updated.xp += 1;
+        logs.push(`${updated.name} visited one city establishment (+1 gold, +1 XP).`);
+      }
+    }
+  }
+
+  if (adventureCard.suit === 'spades' && actionChoice !== 'convert') {
+    const guard = updated.might + updated.spirit;
+    if (guard < Math.ceil(adventureCard.value / 2)) {
+      updated.hp = clamp(updated.hp - 1, 0, 16);
+      logs.push(`${updated.name} suffered global danger from the adventure deck (-1 HP).`);
+    }
+  }
+
+  return { updated, logs };
+};
+
+const cardLabel = (card: Card | null) => card ? `${card.rank}${SUIT_SYMBOL[card.suit]}` : '—';
+
+export function FantasyFlipGame() {
+  const [humanPlayers, setHumanPlayers] = useState(1);
+  const [botPlayers, setBotPlayers] = useState(1);
+  const [maxRounds, setMaxRounds] = useState(12);
+
+  const [started, setStarted] = useState(false);
+  const [round, setRound] = useState(0);
+  const [gameOver, setGameOver] = useState(false);
+
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [playerDeck, setPlayerDeck] = useState<Card[]>([]);
+  const [adventureDeck, setAdventureDeck] = useState<Card[]>([]);
+  const [playerDiscard, setPlayerDiscard] = useState<Card[]>([]);
+  const [adventureDiscard, setAdventureDiscard] = useState<Card[]>([]);
+
+  const [playerCard, setPlayerCard] = useState<Card | null>(null);
+  const [adventureCard, setAdventureCard] = useState<Card | null>(null);
+  const [log, setLog] = useState<TurnLog[]>([]);
+
+  const ranking = useMemo(() => {
+    return [...players]
+      .sort((a, b) => scorePlayer(b) - scorePlayer(a))
+      .map((player, index) => ({
+        ...player,
+        score: scorePlayer(player),
+        place: index + 1,
+      }));
+  }, [players]);
+
+  const startGame = () => {
+    const totalPlayers = humanPlayers + botPlayers;
+    const initPlayers = Array.from({ length: totalPlayers }, (_, idx) => makePlayer(idx + 1, idx >= humanPlayers));
+    const playerChoicesApplied = initPlayers.map((player) => {
+      if (!player.isBot) return player;
+      return { ...player, ...botActionChoice(player) };
+    });
+
+    setPlayers(playerChoicesApplied);
+    setRound(0);
+    setGameOver(false);
+    setStarted(true);
+    setPlayerDeck(makeDeck());
+    setAdventureDeck(makeDeck());
+    setPlayerDiscard([]);
+    setAdventureDiscard([]);
+    setPlayerCard(null);
+    setAdventureCard(null);
+    setLog([]);
+  };
+
+  const updatePlayerChoice = (playerId: number, field: 'actionChoice' | 'boardChoice', value: ActionType | BoardType) => {
+    setPlayers((previous) => previous.map((player) => {
+      if (player.id !== playerId || player.isBot) return player;
+      return {
+        ...player,
+        [field]: value,
+      } as Player;
+    }));
+  };
+
+  const drawFromDeck = (
+    deck: Card[],
+    discard: Card[],
+    setDeck: (value: Card[]) => void,
+    setDiscard: (value: Card[]) => void,
+  ): Card => {
+    let workingDeck = [...deck];
+    let workingDiscard = [...discard];
+
+    if (workingDeck.length === 0) {
+      workingDeck = [...workingDiscard];
+      for (let i = workingDeck.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [workingDeck[i], workingDeck[j]] = [workingDeck[j], workingDeck[i]];
+      }
+      workingDiscard = [];
+    }
+
+    const drawn = workingDeck.shift();
+    if (!drawn) {
+      throw new Error('Deck draw failed.');
+    }
+
+    setDeck(workingDeck);
+    setDiscard(workingDiscard);
+    return drawn;
+  };
+
+  const nextRound = () => {
+    if (!started || gameOver) return;
+
+    const drawnPlayerCard = drawFromDeck(playerDeck, playerDiscard, setPlayerDeck, setPlayerDiscard);
+    const drawnAdventureCard = drawFromDeck(adventureDeck, adventureDiscard, setAdventureDeck, setAdventureDiscard);
+
+    setPlayerCard(drawnPlayerCard);
+    setAdventureCard(drawnAdventureCard);
+
+    setPlayerDiscard((previous) => [...previous, drawnPlayerCard]);
+    setAdventureDiscard((previous) => [...previous, drawnAdventureCard]);
+
+    const currentRound = round + 1;
+    const pendingLogs: TurnLog[] = [];
+
+    const updatedPlayers = players.map((player) => {
+      const decision = player.isBot ? botActionChoice(player) : {
+        actionChoice: player.actionChoice,
+        boardChoice: player.boardChoice,
+      };
+
+      const { updated, logs } = resolveAction(player, decision.actionChoice, decision.boardChoice, drawnPlayerCard, drawnAdventureCard);
+      pendingLogs.push(...logs.map((text) => ({ round: currentRound, playerName: player.name, text })));
+
+      return {
+        ...updated,
+        actionChoice: decision.actionChoice,
+        boardChoice: decision.boardChoice,
+      };
+    });
+
+    setLog((previous) => [...previous, ...pendingLogs]);
+
+    setPlayers(updatedPlayers);
+    setRound(currentRound);
+
+    const everyoneDefeated = updatedPlayers.every((player) => player.hp <= 0);
+    if (currentRound >= maxRounds || everyoneDefeated) {
+      setGameOver(true);
+    }
+  };
+
+  return (
+    <div className="min-h-[calc(100vh-4rem)] xl:min-h-screen bg-stone-100 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100">
+      <div className="max-w-7xl mx-auto p-4 md:p-8 space-y-6">
+        <header className="rounded-xl border border-amber-600/30 bg-gradient-to-r from-amber-100 via-orange-100 to-yellow-100 dark:from-zinc-900 dark:via-zinc-900 dark:to-zinc-800 p-6 shadow-sm">
+          <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight">FANTASY FLIP</h1>
+          <p className="mt-2 text-sm md:text-base max-w-3xl text-zinc-700 dark:text-zinc-300">
+            A flip-and-write inspired fantasy board game with dual decks, shared adventure boards, dry-erase style progression tracks,
+            and support for solo or bot opponents.
+          </p>
+        </header>
+
+        <section className="grid md:grid-cols-3 gap-4">
+          <div className="rounded-lg border border-zinc-300 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4 space-y-3">
+            <h2 className="font-semibold text-lg">Setup</h2>
+            <label className="block text-sm">
+              Human Players
+              <input
+                className="mt-1 w-full rounded border border-zinc-300 dark:border-zinc-700 bg-transparent p-2"
+                type="number"
+                min={1}
+                max={4}
+                value={humanPlayers}
+                onChange={(event) => setHumanPlayers(clamp(Number(event.target.value) || 1, 1, 4))}
+              />
+            </label>
+            <label className="block text-sm">
+              Computer Players
+              <input
+                className="mt-1 w-full rounded border border-zinc-300 dark:border-zinc-700 bg-transparent p-2"
+                type="number"
+                min={0}
+                max={4}
+                value={botPlayers}
+                onChange={(event) => setBotPlayers(clamp(Number(event.target.value) || 0, 0, 4))}
+              />
+            </label>
+            <label className="block text-sm">
+              Rounds
+              <input
+                className="mt-1 w-full rounded border border-zinc-300 dark:border-zinc-700 bg-transparent p-2"
+                type="number"
+                min={8}
+                max={24}
+                value={maxRounds}
+                onChange={(event) => setMaxRounds(clamp(Number(event.target.value) || 12, 8, 24))}
+              />
+            </label>
+            <button
+              type="button"
+              className="w-full rounded bg-amber-700 hover:bg-amber-800 text-white p-2 font-semibold"
+              onClick={startGame}
+            >
+              {started ? 'Restart Game' : 'Start Game'}
+            </button>
+          </div>
+
+          <div className="rounded-lg border border-zinc-300 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4">
+            <h2 className="font-semibold text-lg mb-3">Round State</h2>
+            <p><strong>Round:</strong> {started ? `${round} / ${maxRounds}` : 'Not started'}</p>
+            <p><strong>Player Deck Card:</strong> {cardLabel(playerCard)}</p>
+            <p><strong>Adventure Deck Card:</strong> {cardLabel(adventureCard)}</p>
+            <p><strong>Player Deck Remaining:</strong> {playerDeck.length}</p>
+            <p><strong>Adventure Deck Remaining:</strong> {adventureDeck.length}</p>
+            {started && (
+              <button
+                type="button"
+                className="mt-4 w-full rounded bg-indigo-700 hover:bg-indigo-800 disabled:bg-zinc-400 text-white p-2 font-semibold"
+                onClick={nextRound}
+                disabled={gameOver}
+              >
+                {gameOver ? 'Game Over' : 'Resolve Next Round'}
+              </button>
+            )}
+          </div>
+
+          <div className="rounded-lg border border-zinc-300 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4 space-y-2">
+            <h2 className="font-semibold text-lg">Victory</h2>
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">Score = stats + progress + resources + relics + XP + remaining HP.</p>
+            <ol className="text-sm space-y-1 mt-2">
+              {ranking.slice(0, 4).map((player) => (
+                <li key={player.id}>
+                  #{player.place} {player.name}: <strong>{player.score}</strong>
+                </li>
+              ))}
+            </ol>
+            {gameOver && ranking[0] && (
+              <p className="mt-3 rounded bg-emerald-100 dark:bg-emerald-900/30 p-2 text-sm">
+                Winner: <strong>{ranking[0].name}</strong>
+              </p>
+            )}
+          </div>
+        </section>
+
+        {started && (
+          <section className="rounded-lg border border-zinc-300 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4">
+            <h2 className="font-semibold text-lg mb-3">Character Boards</h2>
+            <div className="grid xl:grid-cols-2 gap-4">
+              {players.map((player) => (
+                <article key={player.id} className="rounded border border-zinc-300 dark:border-zinc-700 p-3 space-y-2">
+                  <div className="flex justify-between items-center">
+                    <h3 className="font-semibold">{player.name} {player.isBot ? '(CPU)' : ''}</h3>
+                    <span className="text-sm text-zinc-500">HP {player.hp}</span>
+                  </div>
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs">
+                    <p>♠ Might: {player.might}</p>
+                    <p>♥ Spirit: {player.spirit}</p>
+                    <p>♦ Craft: {player.craft}</p>
+                    <p>♣ Lore: {player.lore}</p>
+                    <p>XP: {player.xp}</p>
+                    <p>Focus: {player.focus}</p>
+                    <p>Gold: {player.gold}</p>
+                    <p>Relics: {player.relics}</p>
+                    <p>Materials: {player.materials}</p>
+                    <p>Herbs: {player.herbs}</p>
+                  </div>
+                  <div className="grid md:grid-cols-2 gap-2 text-sm">
+                    <label>
+                      Action
+                      <select
+                        disabled={player.isBot || gameOver}
+                        value={player.actionChoice}
+                        onChange={(event) => updatePlayerChoice(player.id, 'actionChoice', event.target.value as ActionType)}
+                        className="mt-1 w-full rounded border border-zinc-300 dark:border-zinc-700 bg-transparent p-2 disabled:opacity-60"
+                      >
+                        <option value="train">Train</option>
+                        <option value="act">Act</option>
+                        <option value="convert">Convert</option>
+                      </select>
+                    </label>
+                    <label>
+                      Adventure Board
+                      <select
+                        disabled={player.isBot || gameOver}
+                        value={player.boardChoice}
+                        onChange={(event) => updatePlayerChoice(player.id, 'boardChoice', event.target.value as BoardType)}
+                        className="mt-1 w-full rounded border border-zinc-300 dark:border-zinc-700 bg-transparent p-2 disabled:opacity-60"
+                      >
+                        <option value="dungeon">Dungeon</option>
+                        <option value="tower">Tower</option>
+                        <option value="forest">Forest</option>
+                        <option value="city">City</option>
+                      </select>
+                    </label>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section className="rounded-lg border border-zinc-300 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4">
+          <h2 className="font-semibold text-lg mb-3">Adventure Boards</h2>
+          <div className="grid md:grid-cols-2 gap-4">
+            {(Object.keys(BOARD_IMAGES) as BoardType[]).map((boardKey) => (
+              <figure key={boardKey} className="rounded border border-zinc-300 dark:border-zinc-700 p-2 bg-zinc-50 dark:bg-zinc-950">
+                <img src={BOARD_IMAGES[boardKey]} alt={`${BOARD_LABELS[boardKey]} board`} className="w-full h-auto rounded" />
+                <figcaption className="text-sm mt-2 text-zinc-700 dark:text-zinc-300">
+                  <strong>{BOARD_LABELS[boardKey]}:</strong> {boardKey === 'dungeon' && 'Maze crawl with relic rewards and combat checks.'}
+                  {boardKey === 'tower' && 'Vertical arcane ascent with instability pressure.'}
+                  {boardKey === 'forest' && 'Resource gathering loops with danger pulses.'}
+                  {boardKey === 'city' && 'Mini-game districts for conversion combos.'}
+                </figcaption>
+              </figure>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-zinc-300 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4">
+          <h2 className="font-semibold text-lg mb-3">Game Log</h2>
+          <div className="max-h-72 overflow-auto text-sm space-y-2">
+            {log.length === 0 && <p className="text-zinc-500">No turns resolved yet.</p>}
+            {log.slice().reverse().map((entry, index) => (
+              <p key={`${entry.round}-${entry.playerName}-${index}`}>
+                <span className="font-semibold">R{entry.round} · {entry.playerName}</span>: {entry.text}
+              </p>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -32,6 +32,7 @@ import { SITE_NAME, DEFAULT_IMAGE } from './lib/seo';
 import { EventGridRoute } from './routes/event-grid';
 import { ActivityRoute } from './routes/activity';
 import { NotFoundRoute } from './routes/not-found';
+import { FantasyFlipRoute } from './routes/fantasy-flip';
 
 // Lazy load main list components for better code splitting
 const Events = lazyRouteComponent(() => import('./components/Events'));
@@ -310,6 +311,7 @@ const routeTree = rootRoute.addChildren([
     EventGridRoute,
     RadarRoute,
     ActivityRoute,
+    FantasyFlipRoute,
     AboutRoute,
     HelpRoute,
     SearchRoute,

--- a/src/routes/fantasy-flip.tsx
+++ b/src/routes/fantasy-flip.tsx
@@ -1,0 +1,23 @@
+import { createRoute } from '@tanstack/react-router';
+import { rootRoute } from './root';
+import { FantasyFlipGame } from '../components/fantasy-flip/FantasyFlipGame';
+import { SITE_NAME } from '../lib/seo';
+
+export const FantasyFlipRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/fantasy-flip',
+  component: FantasyFlipGame,
+  head: () => {
+    const url = typeof window !== 'undefined' ? window.location.href : 'https://arcane.city/fantasy-flip';
+    return {
+      meta: [
+        { title: `Fantasy Flip • ${SITE_NAME}` },
+        { name: 'description', content: 'A playable web prototype of Fantasy Flip: a two-deck fantasy flip-and-write board game with solo and bot modes.' },
+        { property: 'og:url', content: `${url}` },
+        { property: 'og:type', content: 'website' },
+        { property: 'og:title', content: `Fantasy Flip • ${SITE_NAME}` },
+        { property: 'og:description', content: 'Play Fantasy Flip in your browser with full setup and game loop support.' },
+      ],
+    };
+  },
+});


### PR DESCRIPTION
### Motivation
- Provide a playable in-app prototype of a flip-and-write fantasy mini-game with solo/bot support and shared adventure boards.
- Surface the game in the app navigation so users can discover and try the prototype.
- Include simple illustrative board art assets for each adventure board (Dungeon, Tower, Forest, City).

### Description
- Added a new React component `FantasyFlipGame` implementing the game loop, player/bot logic, two-deck draws, action resolution, scoring, simple UI for setup, rounds, character boards, adventure boards, and a game log located at `src/components/fantasy-flip/FantasyFlipGame.tsx`.
- Added four SVG board images under `public/images/fantasy-flip/`: `dungeon-board.svg`, `tower-board.svg`, `forest-board.svg`, and `city-board.svg` and wired them into the game UI via `BOARD_IMAGES`.
- Introduced a new route `FantasyFlipRoute` at `/fantasy-flip` in `src/routes/fantasy-flip.tsx` and registered it in the router (`src/router.ts`).
- Added a navigation entry for the game in the main menu by updating `src/components/MenuBar.tsx`, including an icon import for `HiSparkles`.

### Testing
- No unit tests were added for this prototype; existing CI is expected to run the repository's automated checks (unit tests, lint, and typecheck) on this change.
- Local development sanity checks were performed: the game component mounts, the route is reachable, and the SVG assets render in the Adventure Boards section during manual verification in a dev build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab66408938832289b984da3c48ca48)